### PR TITLE
fix tm_timer

### DIFF
--- a/System/Classes/tm_timer.cpp
+++ b/System/Classes/tm_timer.cpp
@@ -76,7 +76,7 @@ bench_cumul (string task) {
 }
 
 void
-bench_end (tm_ostream ostream, string task) {
+bench_end (tm_ostream &ostream, string task) {
   // end timer for a given type of task, print result and reset timer
   bench_cumul (task);
   bench_print (ostream, task);
@@ -93,7 +93,7 @@ bench_reset (string task) {
 }
 
 void
-bench_print (tm_ostream ostream, string task) {
+bench_print (tm_ostream &ostream, string task) {
   // print timing for a given type of task
   if (DEBUG_BENCH) {
     int nr= timing_nr[task];
@@ -114,7 +114,7 @@ collect (hashmap<string, int> h) {
 }
 
 void
-bench_print (tm_ostream ostream) {
+bench_print (tm_ostream &ostream) {
   // print timings for all types of tasks
   array<string> a= collect (timing_cumul);
   int           i, n= N (a);

--- a/System/Classes/tm_timer.cpp
+++ b/System/Classes/tm_timer.cpp
@@ -76,7 +76,7 @@ bench_cumul (string task) {
 }
 
 void
-bench_end (tm_ostream &ostream, string task) {
+bench_end (tm_ostream& ostream, string task) {
   // end timer for a given type of task, print result and reset timer
   bench_cumul (task);
   bench_print (ostream, task);
@@ -93,7 +93,7 @@ bench_reset (string task) {
 }
 
 void
-bench_print (tm_ostream &ostream, string task) {
+bench_print (tm_ostream& ostream, string task) {
   // print timing for a given type of task
   if (DEBUG_BENCH) {
     int nr= timing_nr[task];
@@ -114,7 +114,7 @@ collect (hashmap<string, int> h) {
 }
 
 void
-bench_print (tm_ostream &ostream) {
+bench_print (tm_ostream& ostream) {
   // print timings for all types of tasks
   array<string> a= collect (timing_cumul);
   int           i, n= N (a);

--- a/System/Classes/tm_timer.hpp
+++ b/System/Classes/tm_timer.hpp
@@ -44,9 +44,9 @@ time_t texmacs_time ();
 
 void bench_start (string task);
 void bench_cumul (string task);
-void bench_end (tm_ostream &ostream, string task);
+void bench_end (tm_ostream& ostream, string task);
 void bench_reset (string task);
-void bench_print (tm_ostream &ostream, string task);
-void bench_print (tm_ostream &ostream);
+void bench_print (tm_ostream& ostream, string task);
+void bench_print (tm_ostream& ostream);
 
 #endif // defined TIMER_H

--- a/System/Classes/tm_timer.hpp
+++ b/System/Classes/tm_timer.hpp
@@ -15,30 +15,6 @@
 #include "string.hpp"
 #include "tm_ostream.hpp"
 
-#ifndef __FreeBSD__
-#ifndef HAVE_TIME_T
-#define HAVE_TIME_T
-typedef long time_t;
-#endif
-#else
-#include <time.h>
-#endif
-
-#ifdef OS_SUN
-#include <sys/types.h>
-#endif
-
-#ifdef HAVE_GETTIMEOFDAY
-#include <sys/time.h>
-#else
-#include <sys/timeb.h>
-#ifdef OS_SUN
-extern "C" {
-extern int ftime __P ((struct timeb * __timebuf));
-};
-#endif
-#endif
-
 time_t raw_time ();
 time_t texmacs_time ();
 

--- a/System/Classes/tm_timer.hpp
+++ b/System/Classes/tm_timer.hpp
@@ -44,9 +44,9 @@ time_t texmacs_time ();
 
 void bench_start (string task);
 void bench_cumul (string task);
-void bench_end (tm_ostream ostream, string task);
+void bench_end (tm_ostream &ostream, string task);
 void bench_reset (string task);
-void bench_print (tm_ostream ostream, string task);
-void bench_print (tm_ostream ostream);
+void bench_print (tm_ostream &ostream, string task);
+void bench_print (tm_ostream &ostream);
 
 #endif // defined TIMER_H

--- a/System/config_l1.h.xmake
+++ b/System/config_l1.h.xmake
@@ -1,8 +1,7 @@
-${define HAVE_INTPTR_T}
-${define HAVE_STDINT_H}
-${define HAVE_INTTYPES_H}
-${define HAVE_TIME_T}
-${define HAVE_GETTIMEOFDAY}
+${define HAVE_INTPTR_T} ${define HAVE_STDINT_H} ${define HAVE_INTTYPES_H} ${
+    define HAVE_TIME_T} ${define HAVE_GETTIMEOFDAY} ${define __FreeBSD__} $ {
+  define OS_SUN
+}
 
 #ifdef HAVE_INTPTR_T
 #ifdef HAVE_INTTYPES_H
@@ -15,8 +14,31 @@ ${define HAVE_GETTIMEOFDAY}
 typedef long intptr_t;
 #endif
 
-${define SANITY_CHECKS}
-${define OS_MINGW}
-${define OS_WIN32}
-${define MIMALLOC}
-${define JEMALLOC}
+#ifndef __FreeBSD__
+#ifndef HAVE_TIME_T
+#define HAVE_TIME_T
+typedef long time_t;
+#endif
+#else
+#include <time.h>
+#endif
+
+#ifdef OS_SUN
+#include <sys/types.h>
+#endif
+
+#ifdef HAVE_GETTIMEOFDAY
+#include <sys/time.h>
+#else
+#include <sys/timeb.h>
+#ifdef OS_SUN
+extern "C" {
+extern int ftime __P ((struct timeb * __timebuf));
+};
+#endif
+#endif
+
+${define SANITY_CHECKS} ${define OS_MINGW} ${define OS_WIN32} ${
+    define MIMALLOC} $ {
+  define JEMALLOC
+}

--- a/System/config_l1.h.xmake
+++ b/System/config_l1.h.xmake
@@ -1,7 +1,10 @@
-${define HAVE_INTPTR_T} ${define HAVE_STDINT_H} ${define HAVE_INTTYPES_H} ${
-    define HAVE_TIME_T} ${define HAVE_GETTIMEOFDAY} ${define __FreeBSD__} $ {
-  define OS_SUN
-}
+${define HAVE_INTPTR_T} 
+${define HAVE_STDINT_H} 
+${define HAVE_INTTYPES_H} 
+${define HAVE_TIME_T} 
+${define HAVE_GETTIMEOFDAY} 
+${define __FreeBSD__} 
+${define OS_SUN}
 
 #ifdef HAVE_INTPTR_T
 #ifdef HAVE_INTTYPES_H
@@ -38,7 +41,8 @@ extern int ftime __P ((struct timeb * __timebuf));
 #endif
 #endif
 
-${define SANITY_CHECKS} ${define OS_MINGW} ${define OS_WIN32} ${
-    define MIMALLOC} $ {
-  define JEMALLOC
-}
+${define SANITY_CHECKS} 
+${define OS_MINGW} 
+${define OS_WIN32} 
+${define MIMALLOC} 
+${define JEMALLOC}

--- a/tests/System/Classes/tm_timer_test.cpp
+++ b/tests/System/Classes/tm_timer_test.cpp
@@ -1,0 +1,227 @@
+/** \file tm_timer_test.cpp
+ *  \copyright GPLv3
+ *  \details A unitest for tm_timer.
+ *  \author Paradisuman
+ *  \date   2023
+ */
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include "doctest/doctest.h"
+#include "tm_timer.hpp"
+
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+int
+get_timing_cumul (string rep) {
+  auto              out= as_charp (rep);
+  std::stringstream ss (out);
+  std::string       token;
+
+  while (ss >> token) {
+    if (std::isdigit (token[0]) ||
+        (token[0] == '-' && std::isdigit (token[1]))) {
+      return std::stoi (token);
+    }
+  }
+}
+
+int
+get_timing_nr (string rep) {
+  auto              out= as_charp (rep);
+  std::stringstream ss (out);
+  std::string       token;
+
+  while (ss >> token) {
+    if (token[0] == '(') {
+      std::string token1= token.substr (1);
+      return std::stoi (token1);
+    }
+  }
+  return -1;
+}
+
+bool
+test_same (tm_ostream& a, string b) {
+  string sa= a.unbuffer ();
+
+  return sa == b;
+}
+
+string
+to_zero (tm_ostream& out) {
+  string s1     = out.unbuffer ();
+  char*  ans    = as_charp (s1);
+  char*  current= ans;
+  while ((current= strstr (current, "took"))) {
+    current+= strlen ("took");
+    while (*current && (*current == '(')) {
+      current+= 2;
+    }
+    while (*current && (*current < '0' || *current > '9')) {
+      current++;
+    }
+    while (*current && *current >= '0' && *current <= '9') {
+      *current= '0';
+      current++;
+    }
+  }
+  return ans;
+}
+
+TEST_CASE ("function raw_time") {
+  long startTime= raw_time ();
+
+  CHECK (startTime >= 0);
+
+  long endTime= raw_time ();
+
+  CHECK (endTime >= startTime);
+}
+
+TEST_CASE ("function texmacs_time") {
+  long t1= texmacs_time ();
+
+  CHECK (t1 >= 0);
+
+  long t2= raw_time ();
+
+  CHECK (t2 >= t1);
+}
+
+TEST_CASE ("function bench_start and bench_cumul") {
+  debug_set ("bench", true);
+  tm_ostream ostream;
+  ostream.buffer ();
+
+  SUBCASE ("start once") {
+    bench_start ("task1");
+    bench_print (ostream, "task1");
+    string out= ostream.unbuffer ();
+    int    t1 = get_timing_cumul (out);
+
+    CHECK (t1 == 0);
+
+    bench_cumul ("task1");
+    ostream.buffer ();
+    bench_print (ostream, "task1");
+    out   = ostream.unbuffer ();
+    int t2= get_timing_cumul (out);
+
+    CHECK (t2 >= 0);
+  }
+
+  SUBCASE ("start multiple times") {
+    bench_start ("task2");
+
+    bench_cumul ("task2");
+    bench_print (ostream, "task1");
+    string out= ostream.unbuffer ();
+    int    t1 = get_timing_cumul (out);
+
+    CHECK (t1 >= 0);
+    CHECK (get_timing_nr (out) == -1);
+
+    bench_start ("task2");
+
+    bench_cumul ("task2");
+    ostream.buffer ();
+    bench_print (ostream, "task2");
+    out   = ostream.unbuffer ();
+    int t2= get_timing_cumul (out);
+    int nr= get_timing_nr (out);
+
+    CHECK (t2 >= 0);
+    CHECK (nr == 2);
+  }
+}
+
+TEST_CASE ("function bench_end") {
+  debug_set ("bench", true);
+  tm_ostream ostream;
+  ostream.buffer ();
+
+  bench_start ("task");
+  bench_end (ostream, "task");
+  string out= ostream.unbuffer ();
+
+  CHECK (get_timing_nr (out) == -1);
+
+  bench_start ("task");
+  ostream.buffer ();
+  bench_end (ostream, "task");
+  out= ostream.unbuffer ();
+
+  CHECK (get_timing_nr (out) == -1);
+}
+
+TEST_CASE ("function bench_reset") {
+  debug_set ("bench", true);
+  tm_ostream ostream;
+  ostream.buffer ();
+
+  SUBCASE ("if task empty") {
+    bench_reset ("task");
+    bench_print (ostream, "task");
+    string out= ostream.unbuffer ();
+
+    CHECK (get_timing_nr (out) == -1);
+  }
+
+  SUBCASE ("if task not empty") {
+    bench_start ("task");
+    bench_cumul ("task");
+    bench_start ("task");
+    bench_cumul ("task");
+
+    bench_reset ("task");
+    bench_print (ostream, "task");
+    string out= ostream.unbuffer ();
+
+    CHECK (get_timing_nr (out) == -1);
+  }
+}
+
+TEST_CASE ("function bench_print") {
+  debug_set ("bench", true);
+  tm_ostream ostream;
+  ostream.buffer ();
+
+  SUBCASE ("print one task") {
+    bench_print (ostream, "task");
+    string b= "Task 'task' took 0 ms\n";
+
+    CHECK (test_same (ostream, b));
+
+    ostream.buffer ();
+    bench_reset ("task1");
+    bench_start ("task1");
+    bench_cumul ("task1");
+    bench_start ("task1");
+    bench_cumul ("task1");
+    bench_print (ostream, "task1");
+
+    string ans= "Task 'task1' took 0 ms (2 invocations)\n";
+    string out= to_zero (ostream);
+
+    CHECK (out == ans);
+  }
+
+  SUBCASE ("print multiple task") {
+    bench_reset ("task1");
+    bench_reset ("task2");
+
+    bench_start ("task1");
+    bench_cumul ("task1");
+    bench_start ("task2");
+    bench_cumul ("task2");
+    bench_print (ostream);
+
+    string out= to_zero (ostream);
+    string b  = "Task 'task1' took 0 ms\nTask 'task2' took 0 ms\n";
+
+    CHECK (out == b);
+  }
+}

--- a/tests/System/Classes/tm_timer_test.cpp
+++ b/tests/System/Classes/tm_timer_test.cpp
@@ -72,11 +72,11 @@ to_zero (tm_ostream& out) {
 }
 
 TEST_CASE ("function raw_time") {
-  long startTime= raw_time ();
+  unsigned int startTime= raw_time ();
 
   CHECK (startTime >= 0);
 
-  long endTime= raw_time ();
+  unsigned int endTime= raw_time ();
 
   CHECK (endTime >= startTime);
 }

--- a/tests/System/Classes/tm_timer_test.cpp
+++ b/tests/System/Classes/tm_timer_test.cpp
@@ -86,7 +86,7 @@ TEST_CASE ("function texmacs_time") {
 
   CHECK (t1 >= 0);
 
-  long t2= raw_time ();
+  long t2= texmacs_time ();
 
   CHECK (t2 >= t1);
 }


### PR DESCRIPTION
While conducting unit tests, I noticed that in the tm_timer functions, the tm_ostream parameter was not being passed by reference. This caused the memory of tm_ostream to be deallocated when the function finished, resulting in unexpected null pointers. Therefore, I changed these parameters to be passed by reference.