### PR TITLE
[11_4] set minimal xmake version to 2.8.2

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -1,3 +1,5 @@
+set_xmakever("2.8.2")
+
 set_project("lolly")
 
 set_languages("c++17")


### PR DESCRIPTION
Because we are using `add_forceincludes`.
https://xmake.io/#/manual/project_target?id=targetadd_forceincludes