### PR TITLE
[15_1] test of memory leakage  in certain case

### DIFF
--- a/System/Memory/fast_alloc.cpp
+++ b/System/Memory/fast_alloc.cpp
@@ -46,6 +46,11 @@ safe_malloc (size_t sz) {
 void*
 enlarge_malloc (size_t sz) {
   if (alloc_remains < sz) {
+    if (alloc_remains > 0)
+    {
+      ind (alloc_mem)     = alloc_ptr (alloc_remains);
+      alloc_ptr (alloc_remains)= alloc_mem;
+    }
     alloc_mem= (char*) safe_malloc (BLOCK_SIZE);
 #ifdef DEBUG_ON
     alloc_mem_top= alloc_mem_top >= alloc_mem + BLOCK_SIZE

--- a/System/Memory/fast_alloc.cpp
+++ b/System/Memory/fast_alloc.cpp
@@ -46,9 +46,8 @@ safe_malloc (size_t sz) {
 void*
 enlarge_malloc (size_t sz) {
   if (alloc_remains < sz) {
-    if (alloc_remains > 0)
-    {
-      ind (alloc_mem)     = alloc_ptr (alloc_remains);
+    if (alloc_remains > 0) {
+      ind (alloc_mem)          = alloc_ptr (alloc_remains);
       alloc_ptr (alloc_remains)= alloc_mem;
     }
     alloc_mem= (char*) safe_malloc (BLOCK_SIZE);

--- a/tests/System/Memory/fast_alloc_test.cpp
+++ b/tests/System/Memory/fast_alloc_test.cpp
@@ -87,7 +87,7 @@ TEST_CASE ("test tm_*_array") {
 TEST_CASE ("test tm_*") {
   const int bnum=
 #ifdef OS_WASM
-      1 00;
+      150;
 #else
       100000;
 #endif

--- a/tests/System/Memory/fast_alloc_test.cpp
+++ b/tests/System/Memory/fast_alloc_test.cpp
@@ -84,14 +84,10 @@ TEST_CASE ("test tm_*_array") {
   tm_delete_array (p_wide);
 }
 
-TEST_CASE ("test tm_*") {
-  const int bnum=
-#ifdef OS_WASM
-      150;
-#else
-      100000;
-#endif
-  int* volume[bnum];
+#ifndef OS_WASM
+TEST_CASE ("test large bunch of tm_*") {
+  const int bnum= 100000;
+  int*      volume[bnum];
   for (int i= 0; i < bnum; i++) {
     volume[i]= tm_new<int> (35);
   }
@@ -99,8 +95,9 @@ TEST_CASE ("test tm_*") {
     tm_delete (volume[i]);
   }
 }
+#endif
 
-TEST_CASE ("test tm_*_array with class") {
+TEST_CASE ("test large bunch of tm_*_array with class") {
   Complex* volume[NUM];
   for (int i= 0; i < NUM; i++) {
     volume[i]= tm_new_array<Complex> (9);

--- a/tests/System/Memory/fast_alloc_test.cpp
+++ b/tests/System/Memory/fast_alloc_test.cpp
@@ -87,7 +87,7 @@ TEST_CASE ("test tm_*_array") {
 TEST_CASE ("test tm_*") {
   const int bnum=
 #ifdef OS_WASM
-      200;
+      1 00;
 #else
       100000;
 #endif

--- a/tests/System/Memory/fast_alloc_test.cpp
+++ b/tests/System/Memory/fast_alloc_test.cpp
@@ -5,6 +5,7 @@ struct Complex {
 public:
   double re, im;
   Complex (double re_, double im_) : re (re_), im (im_) {}
+  Complex () : re (0.5), im (1.0) {}
   ~Complex () {}
 };
 
@@ -72,6 +73,47 @@ TEST_CASE ("test basic data types") {
 TEST_CASE ("test class") {
   Complex* p_complex= tm_new<Complex> (35.8, 26.2);
   tm_delete (p_complex);
+}
+
+TEST_CASE ("test tm_*_array") {
+  uint8_t* p_complex= tm_new_array<uint8_t> (100);
+  tm_delete_array (p_complex);
+  p_complex= tm_new_array<uint8_t> (20000000);
+  tm_delete_array (p_complex);
+  Complex* p_wide= tm_new_array<Complex> (5000000);
+  tm_delete_array (p_wide);
+}
+
+TEST_MEMORY_LEAK_ALL
+TEST_MEMORY_LEAK_RESET
+
+TEST_CASE ("test tm_*") {
+  const int bnum=
+#ifdef OS_WASM
+      1000;
+#else
+      100000;
+#endif
+  int* volume[bnum];
+  for (int i= 0; i < bnum; i++) {
+    volume[i]= tm_new<int> (35);
+  }
+  for (int i= 0; i < bnum; i++) {
+    tm_delete (volume[i]);
+  }
+}
+
+TEST_MEMORY_LEAK_ALL
+TEST_MEMORY_LEAK_RESET
+
+TEST_CASE ("test tm_*_array with class") {
+  Complex* volume[NUM];
+  for (int i= 0; i < NUM; i++) {
+    volume[i]= tm_new_array<Complex> (9);
+  }
+  for (int i= 0; i < NUM; i++) {
+    tm_delete_array (volume[i]);
+  }
 }
 
 TEST_MEMORY_LEAK_ALL

--- a/tests/System/Memory/fast_alloc_test.cpp
+++ b/tests/System/Memory/fast_alloc_test.cpp
@@ -84,13 +84,10 @@ TEST_CASE ("test tm_*_array") {
   tm_delete_array (p_wide);
 }
 
-TEST_MEMORY_LEAK_ALL
-TEST_MEMORY_LEAK_RESET
-
 TEST_CASE ("test tm_*") {
   const int bnum=
 #ifdef OS_WASM
-      800;
+      200;
 #else
       100000;
 #endif
@@ -102,9 +99,6 @@ TEST_CASE ("test tm_*") {
     tm_delete (volume[i]);
   }
 }
-
-TEST_MEMORY_LEAK_ALL
-TEST_MEMORY_LEAK_RESET
 
 TEST_CASE ("test tm_*_array with class") {
   Complex* volume[NUM];

--- a/tests/System/Memory/fast_alloc_test.cpp
+++ b/tests/System/Memory/fast_alloc_test.cpp
@@ -90,7 +90,7 @@ TEST_MEMORY_LEAK_RESET
 TEST_CASE ("test tm_*") {
   const int bnum=
 #ifdef OS_WASM
-      1000;
+      800;
 #else
       100000;
 #endif

--- a/tests/System/Memory/fast_alloc_test.cpp
+++ b/tests/System/Memory/fast_alloc_test.cpp
@@ -78,9 +78,14 @@ TEST_CASE ("test class") {
 TEST_CASE ("test tm_*_array") {
   uint8_t* p_complex= tm_new_array<uint8_t> (100);
   tm_delete_array (p_complex);
-  p_complex= tm_new_array<uint8_t> (20000000);
+#ifdef OS_WASM
+  const size_t size_prim= 200, size_complex= 100;
+#else
+  const size_t size_prim= 20000000, size_complex= 5000000;
+#endif
+  p_complex= tm_new_array<uint8_t> (size_prim);
   tm_delete_array (p_complex);
-  Complex* p_wide= tm_new_array<Complex> (5000000);
+  Complex* p_wide= tm_new_array<Complex> (size_complex);
   tm_delete_array (p_wide);
 }
 
@@ -95,6 +100,8 @@ TEST_CASE ("test large bunch of tm_*") {
     tm_delete (volume[i]);
   }
 }
+TEST_MEMORY_LEAK_ALL
+TEST_MEMORY_LEAK_RESET
 #endif
 
 TEST_CASE ("test large bunch of tm_*_array with class") {


### PR DESCRIPTION
如果分配新的小对象池，原来小对象池的尾部空间会被浪费，造成内存泄漏。