### PR TITLE
[8_6] draft of tm_resize_array and fast_realloc

### DIFF
--- a/Kernel/Containers/array.ipp
+++ b/Kernel/Containers/array.ipp
@@ -39,12 +39,12 @@ array_rep<T>::resize (int m) {
   int mm= round_length (m, sizeof (T));
   if (mm != nn) {
     if (mm != 0) {
-      int i, k= (m < n ? m : n);
-      T*  b= tm_new_array<T> (mm);
-      for (i= 0; i < k; i++)
-        b[i]= a[i];
-      if (nn != 0) tm_delete_array (a);
-      a= b;
+      if (nn != 0) {
+        a= tm_resize_array<T> (mm, a);
+      }
+      else {
+        a= tm_new_array<T> (mm);
+      }
     }
     else {
       if (nn != 0) tm_delete_array (a);

--- a/Kernel/Types/string.cpp
+++ b/Kernel/Types/string.cpp
@@ -39,12 +39,12 @@ string_rep::resize (int m) {
   int mm= round_length (m);
   if (mm != nn) {
     if (mm != 0) {
-      int   i, k= (m < n ? m : n);
-      char* b= tm_new_array<char> (mm);
-      for (i= 0; i < k; i++)
-        b[i]= a[i];
-      if (nn != 0) tm_delete_array (a);
-      a= b;
+      if (nn != 0) {
+        a= tm_resize_array<char> (mm, a);
+      }
+      else {
+        a= tm_new_array<char> (mm);
+      }
     }
     else if (nn != 0) tm_delete_array (a);
   }

--- a/System/Memory/fast_alloc.hpp
+++ b/System/Memory/fast_alloc.hpp
@@ -27,6 +27,7 @@
 
 extern void* fast_alloc (size_t s);
 extern void  fast_free (void* ptr, size_t s);
+extern void* fast_realloc (void* ptr, size_t old_size, size_t new_size);
 extern void* fast_new (size_t s);
 extern void  fast_delete (void* ptr);
 
@@ -413,6 +414,21 @@ tm_new_array (int n) {
   for (int i= 0; i < n; i++, ctr++)
     (void) new ((void*) ctr) C ();
   return (C*) ptr;
+}
+template <typename C>
+inline C*
+tm_resize_array (int new_num, C* Ptr) {
+  void* old_arr    = (void*) Ptr;
+  old_arr          = (void*) (((char*) old_arr) - WORD_LENGTH);
+  int   old_num    = *((int*) old_arr);
+  void* new_arr    = fast_realloc (old_arr, old_num * sizeof (C) + WORD_LENGTH,
+                                   new_num * sizeof (C) + WORD_LENGTH);
+  *((int*) new_arr)= new_num;
+  new_arr          = (void*) (((char*) new_arr) + WORD_LENGTH);
+  C* ctr           = (C*) new_arr + old_num;
+  for (int i= old_num; i < new_num; i++, ctr++)
+    (void) new ((void*) ctr) C ();
+  return (C*) new_arr;
 }
 
 template <typename C>

--- a/System/Memory/impl/je_malloc.cpp
+++ b/System/Memory/impl/je_malloc.cpp
@@ -42,7 +42,7 @@ fast_free (void* ptr, size_t sz) {
 
 void*
 fast_realloc (void* ptr, size_t, size_t new_size) {
-  void* new_ptr= realloc(ptr, new_size);
+  void* new_ptr= realloc (ptr, new_size);
 
   if (new_ptr == NULL) {
     cerr << "Fatal error: out of memory\n";

--- a/System/Memory/impl/je_malloc.cpp
+++ b/System/Memory/impl/je_malloc.cpp
@@ -41,6 +41,17 @@ fast_free (void* ptr, size_t sz) {
 }
 
 void*
+fast_realloc (void* ptr, size_t, size_t new_size) {
+  void* new_ptr= realloc(ptr, new_size);
+
+  if (new_ptr == NULL) {
+    cerr << "Fatal error: out of memory\n";
+    abort ();
+  }
+  return new_ptr;
+}
+
+void*
 fast_new (size_t s) {
   return safe_malloc (s);
 }

--- a/System/Memory/impl/mi_malloc.cpp
+++ b/System/Memory/impl/mi_malloc.cpp
@@ -30,6 +30,11 @@ fast_free (void* ptr, size_t sz) {
 }
 
 void*
+fast_realloc (void* ptr, size_t, size_t new_size) {
+  return mi_realloc(ptr, new_size);
+}
+
+void*
 fast_new (size_t s) {
   return mi_malloc (s);
 }

--- a/System/Memory/impl/mi_malloc.cpp
+++ b/System/Memory/impl/mi_malloc.cpp
@@ -31,7 +31,7 @@ fast_free (void* ptr, size_t sz) {
 
 void*
 fast_realloc (void* ptr, size_t, size_t new_size) {
-  return mi_realloc(ptr, new_size);
+  return mi_realloc (ptr, new_size);
 }
 
 void*


### PR DESCRIPTION
use `realloc` to optimize performance