### PR TITLE
[8_8] Optimize comparison between string

### DIFF
--- a/Kernel/Types/string.cpp
+++ b/Kernel/Types/string.cpp
@@ -181,24 +181,22 @@ operator* (string a, const char* b) {
 
 bool
 operator< (string s1, string s2) {
-  int i;
-  for (i= 0; i < N (s1); i++) {
-    if (i >= N (s2)) return false;
+  int i, n1= N (s1), n2= N (s2), nmin= min (n1, n2);
+  for (i= 0; i < nmin; i++) {
     if (s1[i] < s2[i]) return true;
     if (s2[i] < s1[i]) return false;
   }
-  return i < N (s2);
+  return n1 < n2;
 }
 
 bool
 operator<= (string s1, string s2) {
-  int i;
-  for (i= 0; i < N (s1); i++) {
-    if (i >= N (s2)) return false;
+  int i, n1= N (s1), n2= N (s2), nmin= min (n1, n2);
+  for (i= 0; i < nmin; i++) {
     if (s1[i] < s2[i]) return true;
     if (s2[i] < s1[i]) return false;
   }
-  return true;
+  return n1 <= n2;
 }
 
 tm_ostream&

--- a/bench/Kernel/Types/string_bench.cpp
+++ b/bench/Kernel/Types/string_bench.cpp
@@ -26,6 +26,10 @@ main () {
     static string a ("ab"), b ("b");
     a <= b;
   });
+  bench.run ("compare larger string", [&] {
+    static string a ("compare larger string"), b ("compare LARGER string");
+    a <= b;
+  });
   bench.run ("slice string", [&] {
     static string a ("abcde");
     a (2, 3);


### PR DESCRIPTION
Optimize comparison of two string by dictionary order. After this work, performance of large string comparison is improved twice, however short one is not improved.

## Performance

### Before

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               22.16 |       45,121,128.76 |    0.2% |      0.01 | `compare string`
|              145.29 |        6,882,788.16 |    1.5% |      0.01 | `compare larger string`
### After
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               23.05 |       43,390,782.34 |    4.6% |      0.01 | `compare string`
|               68.25 |       14,651,940.51 |    1.5% |      0.01 | `compare larger string`