### PR TITLE
[8_8] optimization and corresponding benchmarks for string equality comparison

### DIFF
--- a/Kernel/Types/string.cpp
+++ b/Kernel/Types/string.cpp
@@ -106,7 +106,7 @@ bool
 string::operator== (string a) {
   int i;
   if (rep->n != a->n) return false;
-  char* S = rep->a, *s = a->a;
+  char *S= rep->a, *s= a->a;
   for (i= 0; i < rep->n; i++)
     if (S[i] != s[i]) return false;
   return true;
@@ -116,7 +116,7 @@ bool
 string::operator!= (string a) {
   int i;
   if (rep->n != a->n) return true;
-  char* S = rep->a, *s = a->a;
+  char *S= rep->a, *s= a->a;
   for (i= 0; i < rep->n; i++)
     if (S[i] != s[i]) return true;
   return false;

--- a/Kernel/Types/string.cpp
+++ b/Kernel/Types/string.cpp
@@ -106,9 +106,9 @@ bool
 string::operator== (string a) {
   int i;
   if (rep->n != a->n) return false;
-  char *S= rep->a, *s= a->a;
+  char *S_left= rep->a, *S_right= a->a;
   for (i= 0; i < rep->n; i++)
-    if (S[i] != s[i]) return false;
+    if (S_left[i] != S_right[i]) return false;
   return true;
 }
 
@@ -116,9 +116,9 @@ bool
 string::operator!= (string a) {
   int i;
   if (rep->n != a->n) return true;
-  char *S= rep->a, *s= a->a;
+  char *S_left= rep->a, *S_right= a->a;
   for (i= 0; i < rep->n; i++)
-    if (S[i] != s[i]) return true;
+    if (S_left[i] != S_right[i]) return true;
   return false;
 }
 

--- a/Kernel/Types/string.cpp
+++ b/Kernel/Types/string.cpp
@@ -106,8 +106,9 @@ bool
 string::operator== (string a) {
   int i;
   if (rep->n != a->n) return false;
+  char* S = rep->a, *s = a->a;
   for (i= 0; i < rep->n; i++)
-    if (rep->a[i] != a->a[i]) return false;
+    if (S[i] != s[i]) return false;
   return true;
 }
 
@@ -115,8 +116,9 @@ bool
 string::operator!= (string a) {
   int i;
   if (rep->n != a->n) return true;
+  char* S = rep->a, *s = a->a;
   for (i= 0; i < rep->n; i++)
-    if (rep->a[i] != a->a[i]) return true;
+    if (S[i] != s[i]) return true;
   return false;
 }
 

--- a/bench/Kernel/Types/string_bench.cpp
+++ b/bench/Kernel/Types/string_bench.cpp
@@ -23,7 +23,8 @@ main () {
     a == b;
   });
   bench.run ("equality of larger string", [&] {
-    static string a ("equality of larger string"), b ("equality of larger strinG");
+    static string a ("equality of larger string"),
+        b ("equality of larger strinG");
     a == b;
   });
   bench.run ("compare string", [&] {

--- a/bench/Kernel/Types/string_bench.cpp
+++ b/bench/Kernel/Types/string_bench.cpp
@@ -22,6 +22,10 @@ main () {
     static string a ("abc"), b;
     a == b;
   });
+  bench.run ("equality of larger string", [&] {
+    static string a ("equality of larger string"), b ("equality of larger strinG");
+    a == b;
+  });
   bench.run ("compare string", [&] {
     static string a ("ab"), b ("b");
     a <= b;
@@ -31,8 +35,12 @@ main () {
     a <= b;
   });
   bench.run ("slice string", [&] {
-    static string a ("abcde");
+    static string a ("abcdefgh");
     a (2, 3);
+  });
+  bench.run ("slice string with larger range", [&] {
+    static string a ("abcdefgh");
+    a (1, 6);
   });
   bench.minEpochIterations (40000);
   bench.run ("concat string", [&] {


### PR DESCRIPTION
Optimize comparison of two string by dictionary order. After this work, performance of large string comparison is improved twice, however short one is not improved.

## Performance

### Before

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                7.56 |      132,277,551.74 |    2.1% |      0.01 | `equality of string`
|               71.04 |       14,076,915.97 |    3.9% |      0.01 | `equality of larger string`
### After
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                7.57 |      132,048,943.08 |    0.9% |      0.01 | `equality of string`
|               43.94 |       22,759,046.05 |    2.4% |      0.01 | `equality of larger string`