### PR TITLE
[15_1] avoid false-positive of memory leakage in test

### DIFF
--- a/Kernel/Abstractions/basic.hpp
+++ b/Kernel/Abstractions/basic.hpp
@@ -71,8 +71,10 @@ extern string the_exception;
 void tm_throw (const char* msg);
 
 /**
- * @brief Function used to handle exceptions by displaying the exception message
- * and exiting the program.
+ * @brief Function used to handle exceptions by displaying and clearing the
+ * exception message.
+ * @note if catching an exception throwed by \ref tm_throw, this function must
+ * be appended after catch(){...} block.
  */
 void handle_exceptions ();
 

--- a/tests/Kernel/Containers/rel_hashmap_test.cpp
+++ b/tests/Kernel/Containers/rel_hashmap_test.cpp
@@ -47,7 +47,7 @@ TEST_CASE ("test shorten") {
   rel_hashmap<int, int> t (0);
 
   SUBCASE ("test Shorten the empty rel_hashmap") {
-    CHECK_THROWS (t->shorten ());
+    TM_CHECK_THROWS (t->shorten ());
   }
 
   SUBCASE ("test not Shorten the empty rel_hashmap") {
@@ -76,7 +76,9 @@ TEST_CASE ("test shorten") {
 TEST_CASE ("test merge") {
   rel_hashmap<int, int> t (0);
 
-  SUBCASE ("test merge the empty rel_hashmap") { CHECK_THROWS (t->merge ()); }
+  SUBCASE ("test merge the empty rel_hashmap") {
+    TM_CHECK_THROWS (t->merge ());
+  }
 
   hashmap<int, int> hm1 (0, 10);
   hm1 (1)= 10;

--- a/tests/System/Files/file_test.cpp
+++ b/tests/System/Files/file_test.cpp
@@ -282,8 +282,12 @@ TEST_CASE ("load_string from newly created file") {
   }
 }
 
+#ifdef OS_WASM
+// because exception throw, some object will not be released.
+TEST_MEMORY_LEAK_ALL
+#endif
+
 TEST_CASE ("load_string from 3 local files and check exception") {
-  url    lolly_tmp= get_lolly_tmp ();
   url    u1       = url_pwd () * url ("tests/System/Files/sample_file.txt");
   url    u2= url_pwd () * url ("tests/System/Files/sample_file_copy.txt");
   url    u3= url_pwd () * url ("tests/System/Files/sample_file_throw.txt");
@@ -294,6 +298,11 @@ TEST_CASE ("load_string from 3 local files and check exception") {
 
   TM_CHECK_THROWS (load_string (u3, s3, true));
 }
+
+#ifdef OS_WASM
+// because exception throw, some object will not be released.
+TEST_MEMORY_LEAK_RESET
+#endif
 
 TEST_CASE ("load_string from url with :") {
   url u=

--- a/tests/System/Files/file_test.cpp
+++ b/tests/System/Files/file_test.cpp
@@ -288,7 +288,7 @@ TEST_MEMORY_LEAK_ALL
 #endif
 
 TEST_CASE ("load_string from 3 local files and check exception") {
-  url    u1       = url_pwd () * url ("tests/System/Files/sample_file.txt");
+  url    u1= url_pwd () * url ("tests/System/Files/sample_file.txt");
   url    u2= url_pwd () * url ("tests/System/Files/sample_file_copy.txt");
   url    u3= url_pwd () * url ("tests/System/Files/sample_file_throw.txt");
   string s1, s2, s3;

--- a/tests/System/Files/file_test.cpp
+++ b/tests/System/Files/file_test.cpp
@@ -282,8 +282,6 @@ TEST_CASE ("load_string from newly created file") {
   }
 }
 
-TEST_MEMORY_LEAK_ALL
-
 TEST_CASE ("load_string from 3 local files and check exception") {
   url    lolly_tmp= get_lolly_tmp ();
   url    u1       = url_pwd () * url ("tests/System/Files/sample_file.txt");
@@ -294,10 +292,8 @@ TEST_CASE ("load_string from 3 local files and check exception") {
   CHECK (!load_string (u2, s2, false));
   string_eq (s1, s2);
 
-  CHECK_THROWS (load_string (u3, s3, true));
+  TM_CHECK_THROWS (load_string (u3, s3, true));
 }
-// because exception throw, some object will not be released.
-TEST_MEMORY_LEAK_RESET
 
 TEST_CASE ("load_string from url with :") {
   url u=

--- a/tests/lolly_doctests.hpp
+++ b/tests/lolly_doctests.hpp
@@ -39,6 +39,10 @@ url_neq (url left, url right) {
   CHECK_EQ (left != right, true);
 }
 
+#define TM_CHECK_THROWS(statements)                                            \
+  CHECK_THROWS (statements);                                                   \
+  handle_exceptions ();
+
 #define TEST_MEMORY_LEAK_ALL                                                   \
   TEST_CASE ("test memory leak above") { CHECK_EQ (mem_used (), mem_lolly); }
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -240,9 +240,9 @@ function add_test_target(filepath)
         add_files(filepath) 
 
         if is_plat("wasm") then
-            add_cxxflags("-sDISABLE_EXCEPTION_CATCHING=0")
+            add_cxxflags("-s DISABLE_EXCEPTION_CATCHING=0")
             set_values("wasm.preloadfiles", {"xmake.lua", "tests", "LICENSE"})
-            add_ldflags("-sDISABLE_EXCEPTION_CATCHING=0")
+            add_ldflags("-s DISABLE_EXCEPTION_CATCHING=0")
             on_run(function (target)
                 node = os.getenv("EMSDK_NODE")
                 os.cd("$(buildir)/wasm/wasm32/$(mode)/")

--- a/xmake.lua
+++ b/xmake.lua
@@ -240,9 +240,9 @@ function add_test_target(filepath)
         add_files(filepath) 
 
         if is_plat("wasm") then
-            add_cxxflags("-s DISABLE_EXCEPTION_CATCHING=0")
+            add_cxxflags("-sDISABLE_EXCEPTION_CATCHING=0")
             set_values("wasm.preloadfiles", {"xmake.lua", "tests", "LICENSE"})
-            add_ldflags("-s DISABLE_EXCEPTION_CATCHING=0")
+            add_ldflags("-sDISABLE_EXCEPTION_CATCHING=0")
             on_run(function (target)
                 node = os.getenv("EMSDK_NODE")
                 os.cd("$(buildir)/wasm/wasm32/$(mode)/")


### PR DESCRIPTION
- improve document for exception handling
- clear error message to avoid errneous memory growth report