### PR TITLE
[8_9] Perf tuning on descends

### DIFF
--- a/System/Classes/url.cpp
+++ b/System/Classes/url.cpp
@@ -543,9 +543,21 @@ factor (url u) {
 bool
 descends (url u, url base) {
   if (u == base) return true;
-  if (is_concat (u) && is_concat (base))
-    return u[1] == base[1] && descends (u[2], base[2]);
   if (is_concat (u) && is_atomic (base)) return u[1] == base;
+  if (is_concat (u) && is_concat (base)) {
+    url iter_u= u, iter_base= base;
+    while (iter_u[1] == iter_base[1]) {
+      iter_u   = iter_u[2];
+      iter_base= iter_base[2];
+      if (is_concat (iter_u) && is_concat (iter_base)) {
+        continue;
+      }
+      else {
+        return descends (iter_u, iter_base);
+      }
+    }
+    return false;
+  }
   if (is_or (u)) return descends (u[1], base) && descends (u[2], base);
   if (is_or (base)) return descends (u, base[1]) || descends (u, base[2]);
   return false;

--- a/System/Classes/url.cpp
+++ b/System/Classes/url.cpp
@@ -542,12 +542,12 @@ factor (url u) {
 
 bool
 descends (url u, url base) {
-  if (is_or (u)) return descends (u[1], base) && descends (u[2], base);
-  if (is_or (base)) return descends (u, base[1]) || descends (u, base[2]);
   if (u == base) return true;
-  if (is_concat (u) && is_atomic (base)) return u[1] == base;
   if (is_concat (u) && is_concat (base))
     return u[1] == base[1] && descends (u[2], base[2]);
+  if (is_concat (u) && is_atomic (base)) return u[1] == base;
+  if (is_or (u)) return descends (u[1], base) && descends (u[2], base);
+  if (is_or (base)) return descends (u, base[1]) || descends (u, base[2]);
   return false;
 }
 

--- a/bench/System/Classes/url_bench.cpp
+++ b/bench/System/Classes/url_bench.cpp
@@ -1,0 +1,21 @@
+/** \file url_bench.cpp
+ *  \copyright GPLv3
+ *  \details Benchmark for url
+ *  \author Darcy Shen
+ *  \date   2024
+ */
+
+#include "sys_utils.hpp"
+#include "url.hpp"
+#include <nanobench.h>
+
+static ankerl::nanobench::Bench bench;
+
+int
+main () {
+  lolly::init_tbox ();
+  bench.run ("url descends equal",
+             [&] { descends (url ("a/b/c"), url ("a/b/c")); });
+  bench.run ("url descends concat",
+             [&] { descends (url ("a/b/c"), url ("a/b/c/d/e/f")); });
+}

--- a/bench/System/Classes/url_bench.cpp
+++ b/bench/System/Classes/url_bench.cpp
@@ -16,6 +16,9 @@ main () {
   lolly::init_tbox ();
   bench.run ("url descends equal",
              [&] { descends (url ("a/b/c"), url ("a/b/c")); });
-  bench.run ("url descends concat",
-             [&] { descends (url ("a/b/c"), url ("a/b/c/d/e/f")); });
+  bench.run ("url descends concat 2",
+             [&] { descends (url ("a/b/c/d/e/f"), url ("a/b")); });
+  bench.run ("url descends concat 8", [&] {
+    descends (url ("a/b/c/d/e/f/g/h/i/j"), url ("a/b/c/d/e/f/g/h"));
+  });
 }


### PR DESCRIPTION
## Optimization 2
```
# Before
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|            8,400.00 |          119,047.62 |    0.2% |      0.01 | `url descends equal`
|           12,203.41 |           81,944.32 |    0.8% |      0.01 | `url descends concat 2`
|           37,293.00 |           26,814.68 |    0.7% |      0.01 | `url descends concat 8`

# After

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|            8,395.67 |          119,109.03 |    0.2% |      0.01 | `url descends equal`
|           12,189.40 |           82,038.51 |    0.5% |      0.01 | `url descends concat 2`
|           32,826.84 |           30,462.87 |    0.2% |      0.01 | `url descends concat 8`
```

## Optimization 1
Adjust the order (url_or should be put at the end)
```
# Before

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|            8,482.58 |          117,888.63 |    0.3% |      0.01 | `url descends equal`
|           14,931.67 |           66,971.76 |    0.3% |      0.01 | `url descends concat`

# After

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|            8,385.20 |          119,257.80 |    0.1% |      0.01 | `url descends equal`
|           14,816.56 |           67,492.06 |    1.3% |      0.01 | `url descends concat`
```