### PR TITLE
[8_9] Perf tuning on url_get_name

### DIFF
--- a/Kernel/Types/analyze.cpp
+++ b/Kernel/Types/analyze.cpp
@@ -945,7 +945,8 @@ parse (string s, int& pos, SI*& a, int len) {
 
 int
 index_of (string s, char c) {
-  for (int i= 0; i < N (s); i++) {
+  int s_N= N (s);
+  for (int i= 0; i < s_N; i++) {
     if (s[i] == c) {
       return i;
     }
@@ -990,6 +991,17 @@ occurs (string what, string in) {
 bool
 contains (string s, string what) {
   return search_forwards (what, 0, s) >= 0;
+}
+
+bool
+contains (string s, char c) {
+  int s_N= N (s);
+  for (int i= 0; i < s_N; i++) {
+    if (s[i] == c) {
+      return true;
+    }
+  }
+  return false;
 }
 
 int

--- a/Kernel/Types/analyze.hpp
+++ b/Kernel/Types/analyze.hpp
@@ -491,6 +491,7 @@ int count_occurrences (string what, string in);
 bool occurs (string what, string in);
 
 bool contains (string s, string what);
+bool contains (string s, char c);
 
 /**
  * Finds the length of the longest string that is both a suffix of the first

--- a/System/Classes/url.cpp
+++ b/System/Classes/url.cpp
@@ -177,7 +177,7 @@ url_get_atom (string s, int type) {
       return unblank (url_system (val));
     }
   }
-  if (occurs ("*", s)) return url_wildcard (s);
+  if (contains (s, '*')) return url_wildcard (s);
 #ifdef WINPATHS
   if (N (s) == 2 && ends (s, ":"))
     s->resize (1); // remove the ':' after unit letter

--- a/bench/System/Classes/url_bench.cpp
+++ b/bench/System/Classes/url_bench.cpp
@@ -14,6 +14,7 @@ static ankerl::nanobench::Bench bench;
 int
 main () {
   lolly::init_tbox ();
+  bench.run ("url construct 8", [&] { url ("a/b/c/d/e/f/g/h"); });
   bench.run ("url descends equal",
              [&] { descends (url ("a/b/c"), url ("a/b/c")); });
   bench.run ("url descends concat 2",


### PR DESCRIPTION
```
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|            8,395.67 |          119,109.03 |    0.2% |      0.01 | `url descends equal`
|           12,189.40 |           82,038.51 |    0.5% |      0.01 | `url descends concat 2`
|           32,826.84 |           30,462.87 |    0.2% |      0.01 | `url descends concat 8`

# 1
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|           11,964.64 |           83,579.62 |    0.5% |      0.01 | `url construct 8`

#2 
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|            8,918.92 |          112,121.17 |    0.1% |      0.01 | `url construct 8`
|            7,473.30 |          133,809.77 |    0.8% |      0.01 | `url descends equal`
|            9,845.44 |          101,569.82 |    0.4% |      0.01 | `url descends concat 2`
|           23,874.12 |           41,886.35 |    0.2% |      0.01 | `url descends concat 8`
```