### PR TITLE
[19_5] improve performance of resize and provide reserve

### DIFF
--- a/lolly/data/lolly_string.hpp
+++ b/lolly/data/lolly_string.hpp
@@ -19,15 +19,17 @@ template <typename T> class lolly_string;
 template <typename T> int N (lolly_string<T> a);
 template <typename T> class lolly_string_rep : concrete_struct {
   int n;
+  int a_size;
   T*  a;
 
 public:
-  inline lolly_string_rep () : n (0), a (NULL) {}
+  inline lolly_string_rep () : n (0), a_size (0), a (NULL) {}
   lolly_string_rep (int n);
   inline ~lolly_string_rep () {
     if (n != 0) tm_delete_array (a);
   }
   void resize (int n);
+  void reserve (int n);
 
   friend class lolly_string<T>;
   friend int N<> (lolly_string<T> a);

--- a/lolly/data/lolly_string.hpp
+++ b/lolly/data/lolly_string.hpp
@@ -28,7 +28,7 @@ public:
   inline ~lolly_string_rep () {
     if (n != 0) tm_delete_array (a);
   }
-  void expand (int n);
+  int expand_by (int delta);
   void resize (int n);
   void reserve (int n);
 

--- a/lolly/data/lolly_string.hpp
+++ b/lolly/data/lolly_string.hpp
@@ -28,8 +28,27 @@ public:
   inline ~lolly_string_rep () {
     if (n != 0) tm_delete_array (a);
   }
+  /**
+   * @brief expand (or shrink) string by delta, but do not release memory when
+   * string is shrinked.
+   *
+   * @return string length before expansionl
+   */
   int expand_by (int delta);
+
+  /**
+   * @brief expand (or shrink) string to given length n, and try to release
+   * memory when string is shrinked.
+   *
+   * @note expand_by may be faster if memory space is reserved
+   */
   void resize (int n);
+
+  /**
+   * @brief reserve memory space to contain at least n word in the whole string.
+   * Do not affect length of string, and do not release memory when n is smaller
+   * than current space.
+   */
   void reserve (int n);
 
   friend class lolly_string<T>;

--- a/lolly/data/lolly_string.hpp
+++ b/lolly/data/lolly_string.hpp
@@ -28,6 +28,7 @@ public:
   inline ~lolly_string_rep () {
     if (n != 0) tm_delete_array (a);
   }
+  void expand (int n);
   void resize (int n);
   void reserve (int n);
 

--- a/lolly/data/lolly_string.hpp
+++ b/lolly/data/lolly_string.hpp
@@ -19,11 +19,11 @@ template <typename T> class lolly_string;
 template <typename T> int N (lolly_string<T> a);
 template <typename T> class lolly_string_rep : concrete_struct {
   int n;
-  int a_size;
+  int a_N;
   T*  a;
 
 public:
-  inline lolly_string_rep () : n (0), a_size (0), a (NULL) {}
+  inline lolly_string_rep () : n (0), a_N (0), a (NULL) {}
   lolly_string_rep (int n);
   inline ~lolly_string_rep () {
     if (n != 0) tm_delete_array (a);
@@ -34,13 +34,13 @@ public:
    *
    * @return string length before expansionl
    */
-  int expand_by (int delta);
+  int expand_or_shrink_by (int delta);
 
   /**
    * @brief expand (or shrink) string to given length n, and try to release
    * memory when string is shrinked.
    *
-   * @note expand_by may be faster if memory space is reserved
+   * @note expand_or_shrink_by may be faster if memory space is reserved
    */
   void resize (int n);
 

--- a/lolly/data/lolly_string.hpp
+++ b/lolly/data/lolly_string.hpp
@@ -32,7 +32,7 @@ public:
    * @brief expand (or shrink) string by delta, but do not release memory when
    * string is shrinked.
    *
-   * @return string length before expansionl
+   * @return string length before expansion
    */
   int expand_or_shrink_by (int delta);
 

--- a/lolly/data/lolly_string.ipp
+++ b/lolly/data/lolly_string.ipp
@@ -29,6 +29,30 @@ lolly_string_rep<T>::lolly_string_rep (int n2)
 template <class T>
 void
 lolly_string_rep<T>::resize (int new_n) {
+  int old_size= a_size, new_size= round_length (new_n);
+  if (new_n != 0) {
+    if (old_size == 0) {
+      a_size= new_size;
+      a     = tm_new_array<T> (a_size);
+    }
+    else if (old_size != new_size) {
+      a_size= new_size;
+      a     = tm_resize_array<T> (a_size, a);
+    }
+  }
+  else {
+    if (old_size != 0) {
+      tm_delete_array (a);
+      a     = NULL;
+      a_size= 0;
+    };
+  }
+  n= new_n;
+}
+
+template <class T>
+void
+lolly_string_rep<T>::expand (int new_n) {
   reserve (new_n);
   n= new_n;
 }
@@ -146,7 +170,7 @@ template <typename T>
 lolly_string<T>&
 operator<< (lolly_string<T>& a, T ch) {
   int i, na= N (a);
-  a->resize (na + 1);
+  a->expand (na + 1);
   a[na]= ch;
   return a;
 };
@@ -155,7 +179,7 @@ template <typename T>
 inline lolly_string<T>&
 operator<< (lolly_string<T>& a, lolly_string<T> b) {
   int i, na= N (a), nb= N (b);
-  a->resize (na + nb);
+  a->expand (na + nb);
   for (i= 0; i < nb; i++)
     a[i + na]= b[i];
   return a;
@@ -165,7 +189,7 @@ template <typename T>
 inline lolly_string<T>&
 operator<< (lolly_string<T>& a, const lolly_string_view<T>& b) {
   int i, na= N (a);
-  a->resize (na + b.N);
+  a->expand (na + b.N);
   for (i= 0; i < b.N; i++)
     a[i + na]= b.a[i];
   return a;
@@ -176,7 +200,7 @@ inline lolly_string<T>&
 operator<< (lolly_string<T>& a, const T (&b)[Nb]) {
   int           i, na= N (a);
   constexpr int nb= Nb - 1;
-  a->resize (na + nb);
+  a->expand (na + nb);
   for (i= 0; i < nb; i++)
     a[i + na]= b[i];
   return a;

--- a/lolly/data/lolly_string.ipp
+++ b/lolly/data/lolly_string.ipp
@@ -44,7 +44,7 @@ lolly_string_rep<T>::resize (int m) {
     }
     else if (nn != 0) {
       a_size= 0;
-      tm_delete_array (a)
+      tm_delete_array (a);
     };
   }
   n= m;
@@ -189,7 +189,7 @@ operator<< (lolly_string<T>& a, lolly_string<T> b) {
 template <typename T>
 inline lolly_string<T>&
 operator<< (lolly_string<T>& a, const lolly_string_view<T>& b) {
-  int i, na= N (a);
+  int i;
   int na= a->expand_by (b.N);
   for (i= 0; i < b.N; i++)
     a[i + na]= b.a[i];
@@ -199,7 +199,7 @@ operator<< (lolly_string<T>& a, const lolly_string_view<T>& b) {
 template <typename T, size_t Nb>
 inline lolly_string<T>&
 operator<< (lolly_string<T>& a, const T (&b)[Nb]) {
-  int           i, na= N (a);
+  int           i;
   constexpr int nb= Nb - 1;
   int           na= a->expand_by (nb);
   for (i= 0; i < nb; i++)

--- a/lolly/data/lolly_string.ipp
+++ b/lolly/data/lolly_string.ipp
@@ -53,9 +53,10 @@ lolly_string_rep<T>::resize (int m) {
 template <class T>
 int
 lolly_string_rep<T>::expand_by (int delta) {
+  int old_n= n;
   n+= delta;
   reserve (n);
-  return n;
+  return old_n;
 }
 
 template <class T>
@@ -170,8 +171,8 @@ operator<< (tm_ostream& out, lolly_string_view<char> a) {
 template <typename T>
 lolly_string<T>&
 operator<< (lolly_string<T>& a, T ch) {
-  int na   = a->expand_by (1);
-  a[na - 1]= ch;
+  int na= a->expand_by (1);
+  a[na] = ch;
   return a;
 };
 
@@ -179,8 +180,7 @@ template <typename T>
 inline lolly_string<T>&
 operator<< (lolly_string<T>& a, lolly_string<T> b) {
   int i, nb= N (b);
-  int new_na= a->expand_by (nb);
-  int na    = new_na - nb;
+  int na= a->expand_by (nb);
   for (i= 0; i < nb; i++)
     a[i + na]= b[i];
   return a;
@@ -190,8 +190,7 @@ template <typename T>
 inline lolly_string<T>&
 operator<< (lolly_string<T>& a, const lolly_string_view<T>& b) {
   int i, na= N (a);
-  int new_na= a->expand_by (b.N);
-  int na    = new_na - b.N;
+  int na= a->expand_by (b.N);
   for (i= 0; i < b.N; i++)
     a[i + na]= b.a[i];
   return a;
@@ -201,9 +200,8 @@ template <typename T, size_t Nb>
 inline lolly_string<T>&
 operator<< (lolly_string<T>& a, const T (&b)[Nb]) {
   int           i, na= N (a);
-  constexpr int nb    = Nb - 1;
-  int           new_na= a->expand_by (nb);
-  int           na    = new_na - nb;
+  constexpr int nb= Nb - 1;
+  int           na= a->expand_by (nb);
   for (i= 0; i < nb; i++)
     a[i + na]= b[i];
   return a;

--- a/lolly/data/lolly_string.ipp
+++ b/lolly/data/lolly_string.ipp
@@ -28,26 +28,26 @@ lolly_string_rep<T>::lolly_string_rep (int n2)
 
 template <class T>
 void
-lolly_string_rep<T>::resize (int new_n) {
-  int old_size= a_size, new_size= round_length (new_n);
-  if (new_n != 0) {
-    if (old_size == 0) {
-      a_size= new_size;
-      a     = tm_new_array<T> (a_size);
+lolly_string_rep<T>::resize (int m) {
+  int nn= round_length (n);
+  int mm= round_length (m);
+  if (mm != nn) {
+    if (mm != 0) {
+      if (nn != 0) {
+        a_size= mm;
+        a     = tm_resize_array<T> (mm, a);
+      }
+      else {
+        a_size= mm;
+        a     = tm_new_array<T> (mm);
+      }
     }
-    else if (old_size != new_size) {
-      a_size= new_size;
-      a     = tm_resize_array<T> (a_size, a);
-    }
-  }
-  else {
-    if (old_size != 0) {
-      tm_delete_array (a);
-      a     = NULL;
+    else if (nn != 0) {
       a_size= 0;
+      tm_delete_array (a)
     };
   }
-  n= new_n;
+  n= m;
 }
 
 template <class T>

--- a/lolly/data/lolly_string.ipp
+++ b/lolly/data/lolly_string.ipp
@@ -35,16 +35,17 @@ lolly_string_rep<T>::resize (int m) {
     if (mm != 0) {
       if (nn != 0) {
         a_N= mm;
-        a     = tm_resize_array<T> (mm, a);
+        a  = tm_resize_array<T> (mm, a);
       }
       else {
         a_N= mm;
-        a     = tm_new_array<T> (mm);
+        a  = tm_new_array<T> (mm);
       }
     }
     else if (nn != 0) {
-      a_N= 0;
       tm_delete_array (a);
+      a_N= 0;
+      a  = NULL;
     };
   }
   n= m;
@@ -66,17 +67,17 @@ lolly_string_rep<T>::reserve (int new_n) {
   if (new_n != 0) {
     if (old_size == 0) {
       a_N= round_length (new_n);
-      a     = tm_new_array<T> (a_N);
+      a  = tm_new_array<T> (a_N);
     }
     else if (old_size < new_n) {
       a_N= round_length (new_n);
-      a     = tm_resize_array<T> (a_N, a);
+      a  = tm_resize_array<T> (a_N, a);
     }
   }
   else {
     if (old_size != 0) {
       tm_delete_array (a);
-      a     = NULL;
+      a  = NULL;
       a_N= 0;
     };
   }

--- a/lolly/data/lolly_string.ipp
+++ b/lolly/data/lolly_string.ipp
@@ -11,7 +11,7 @@
 namespace lolly {
 namespace data {
 
-static inline int
+static inline constexpr int
 round_length (int n) {
   n= (n + 3) & (0xfffffffc);
   if (n < 24) return n;
@@ -23,25 +23,37 @@ round_length (int n) {
 
 template <class T>
 lolly_string_rep<T>::lolly_string_rep (int n2)
-    : n (n2), a ((n == 0) ? ((T*) NULL) : tm_new_array<T> (round_length (n))) {}
+    : n (n2), a_size (round_length (n)),
+      a ((n == 0) ? ((T*) NULL) : tm_new_array<T> (a_size)) {}
 
 template <class T>
 void
-lolly_string_rep<T>::resize (int m) {
-  int nn= round_length (n);
-  int mm= round_length (m);
-  if (mm != nn) {
-    if (mm != 0) {
-      if (nn != 0) {
-        a= tm_resize_array<T> (mm, a);
-      }
-      else {
-        a= tm_new_array<T> (mm);
-      }
+lolly_string_rep<T>::resize (int new_n) {
+  reserve (new_n);
+  n= new_n;
+}
+
+template <class T>
+void
+lolly_string_rep<T>::reserve (int new_n) {
+  int old_size= a_size;
+  if (new_n != 0) {
+    if (old_size == 0) {
+      a_size= round_length (new_n);
+      a     = tm_new_array<T> (a_size);
     }
-    else if (nn != 0) tm_delete_array (a);
+    else if (old_size < new_n) {
+      a_size= round_length (new_n);
+      a     = tm_resize_array<T> (a_size, a);
+    }
   }
-  n= m;
+  else {
+    if (old_size != 0) {
+      tm_delete_array (a);
+      a     = NULL;
+      a_size= 0;
+    };
+  }
 }
 
 template <class T>

--- a/lolly/data/lolly_string.ipp
+++ b/lolly/data/lolly_string.ipp
@@ -51,10 +51,11 @@ lolly_string_rep<T>::resize (int new_n) {
 }
 
 template <class T>
-void
-lolly_string_rep<T>::expand (int new_n) {
-  reserve (new_n);
-  n= new_n;
+int
+lolly_string_rep<T>::expand_by (int delta) {
+  n+= delta;
+  reserve (n);
+  return n;
 }
 
 template <class T>
@@ -169,17 +170,17 @@ operator<< (tm_ostream& out, lolly_string_view<char> a) {
 template <typename T>
 lolly_string<T>&
 operator<< (lolly_string<T>& a, T ch) {
-  int i, na= N (a);
-  a->expand (na + 1);
-  a[na]= ch;
+  int na   = a->expand_by (1);
+  a[na - 1]= ch;
   return a;
 };
 
 template <typename T>
 inline lolly_string<T>&
 operator<< (lolly_string<T>& a, lolly_string<T> b) {
-  int i, na= N (a), nb= N (b);
-  a->expand (na + nb);
+  int i, nb= N (b);
+  int new_na= a->expand_by (nb);
+  int na    = new_na - nb;
   for (i= 0; i < nb; i++)
     a[i + na]= b[i];
   return a;
@@ -189,7 +190,8 @@ template <typename T>
 inline lolly_string<T>&
 operator<< (lolly_string<T>& a, const lolly_string_view<T>& b) {
   int i, na= N (a);
-  a->expand (na + b.N);
+  int new_na= a->expand_by (b.N);
+  int na    = new_na - b.N;
   for (i= 0; i < b.N; i++)
     a[i + na]= b.a[i];
   return a;
@@ -199,8 +201,9 @@ template <typename T, size_t Nb>
 inline lolly_string<T>&
 operator<< (lolly_string<T>& a, const T (&b)[Nb]) {
   int           i, na= N (a);
-  constexpr int nb= Nb - 1;
-  a->expand (na + nb);
+  constexpr int nb    = Nb - 1;
+  int           new_na= a->expand_by (nb);
+  int           na    = new_na - nb;
   for (i= 0; i < nb; i++)
     a[i + na]= b[i];
   return a;

--- a/lolly/data/lolly_string.ipp
+++ b/lolly/data/lolly_string.ipp
@@ -23,8 +23,8 @@ round_length (int n) {
 
 template <class T>
 lolly_string_rep<T>::lolly_string_rep (int n2)
-    : n (n2), a_size (round_length (n)),
-      a ((n == 0) ? ((T*) NULL) : tm_new_array<T> (a_size)) {}
+    : n (n2), a_N (round_length (n)),
+      a ((n == 0) ? ((T*) NULL) : tm_new_array<T> (a_N)) {}
 
 template <class T>
 void
@@ -34,16 +34,16 @@ lolly_string_rep<T>::resize (int m) {
   if (mm != nn) {
     if (mm != 0) {
       if (nn != 0) {
-        a_size= mm;
+        a_N= mm;
         a     = tm_resize_array<T> (mm, a);
       }
       else {
-        a_size= mm;
+        a_N= mm;
         a     = tm_new_array<T> (mm);
       }
     }
     else if (nn != 0) {
-      a_size= 0;
+      a_N= 0;
       tm_delete_array (a);
     };
   }
@@ -52,7 +52,7 @@ lolly_string_rep<T>::resize (int m) {
 
 template <class T>
 int
-lolly_string_rep<T>::expand_by (int delta) {
+lolly_string_rep<T>::expand_or_shrink_by (int delta) {
   int old_n= n;
   n+= delta;
   reserve (n);
@@ -62,22 +62,22 @@ lolly_string_rep<T>::expand_by (int delta) {
 template <class T>
 void
 lolly_string_rep<T>::reserve (int new_n) {
-  int old_size= a_size;
+  int old_size= a_N;
   if (new_n != 0) {
     if (old_size == 0) {
-      a_size= round_length (new_n);
-      a     = tm_new_array<T> (a_size);
+      a_N= round_length (new_n);
+      a     = tm_new_array<T> (a_N);
     }
     else if (old_size < new_n) {
-      a_size= round_length (new_n);
-      a     = tm_resize_array<T> (a_size, a);
+      a_N= round_length (new_n);
+      a     = tm_resize_array<T> (a_N, a);
     }
   }
   else {
     if (old_size != 0) {
       tm_delete_array (a);
       a     = NULL;
-      a_size= 0;
+      a_N= 0;
     };
   }
 }
@@ -171,7 +171,7 @@ operator<< (tm_ostream& out, lolly_string_view<char> a) {
 template <typename T>
 lolly_string<T>&
 operator<< (lolly_string<T>& a, T ch) {
-  int na= a->expand_by (1);
+  int na= a->expand_or_shrink_by (1);
   a[na] = ch;
   return a;
 };
@@ -180,7 +180,7 @@ template <typename T>
 inline lolly_string<T>&
 operator<< (lolly_string<T>& a, lolly_string<T> b) {
   int i, nb= N (b);
-  int na= a->expand_by (nb);
+  int na= a->expand_or_shrink_by (nb);
   for (i= 0; i < nb; i++)
     a[i + na]= b[i];
   return a;
@@ -190,7 +190,7 @@ template <typename T>
 inline lolly_string<T>&
 operator<< (lolly_string<T>& a, const lolly_string_view<T>& b) {
   int i;
-  int na= a->expand_by (b.N);
+  int na= a->expand_or_shrink_by (b.N);
   for (i= 0; i < b.N; i++)
     a[i + na]= b.a[i];
   return a;
@@ -201,7 +201,7 @@ inline lolly_string<T>&
 operator<< (lolly_string<T>& a, const T (&b)[Nb]) {
   int           i;
   constexpr int nb= Nb - 1;
-  int           na= a->expand_by (nb);
+  int           na= a->expand_or_shrink_by (nb);
   for (i= 0; i < nb; i++)
     a[i + na]= b[i];
   return a;

--- a/tests/lolly/data/lolly_string_test.cpp
+++ b/tests/lolly/data/lolly_string_test.cpp
@@ -93,3 +93,46 @@ TEST_CASE ("test reserve along with append") {
     CHECK_EQ (str == u"abc", true);
   }
 }
+
+TEST_CASE ("test expand_or_shrink_by along with sub index") {
+
+  SUBCASE ("expand") {
+    auto str       = string_u16 (u"abc");
+    int  previous_n= str->expand_or_shrink_by (1);
+    CHECK_EQ (previous_n, 3);
+    str[3]= u'd';
+    CHECK_EQ (str == u"abcd", true);
+  }
+  SUBCASE ("shrink") {
+    auto str       = string_u16 (u"abc");
+    int  previous_n= str->expand_or_shrink_by (-1);
+    CHECK_EQ (previous_n, 3);
+    CHECK_EQ (str == u"ab", true);
+  }
+  SUBCASE ("delta 0 takes no effect") {
+    auto str       = string_u16 (u"abc");
+    int  previous_n= str->expand_or_shrink_by (0);
+    CHECK_EQ (previous_n, 3);
+    CHECK_EQ (str == u"abc", true);
+  }
+}
+
+TEST_CASE ("test resize") {
+
+  SUBCASE ("expand") {
+    auto str= string_u16 (u"abc");
+    str->resize (4);
+    str[3]= u'd';
+    CHECK_EQ (str == u"abcd", true);
+  }
+  SUBCASE ("shrink") {
+    auto str= string_u16 (u"abc");
+    str->resize (2);
+    CHECK_EQ (str == u"ab", true);
+  }
+  SUBCASE ("delta 0 takes no effect") {
+    auto str= string_u16 (u"abc");
+    str->resize (3);
+    CHECK_EQ (str == u"abc", true);
+  }
+}

--- a/tests/lolly/data/lolly_string_test.cpp
+++ b/tests/lolly/data/lolly_string_test.cpp
@@ -69,3 +69,14 @@ TEST_CASE ("test append") {
   str << string_u16 (u"yz");
   CHECK_EQ (str == string_u16 (u"xyz"), true);
 }
+
+TEST_CASE ("test reserve along with append") {
+  auto str= string_u16 ();
+  str->reserve (6);
+  str << u'x';
+  CHECK_EQ (str == string_u16 (u"x"), true);
+  str << string_u16 (u"yz");
+  CHECK_EQ (str == string_u16 (u"xyz"), true);
+  str << string_u16 (u": larger than reserved space");
+  CHECK_EQ (str == string_u16 (u"xyz: larger than reserved space"), true);
+}

--- a/tests/lolly/data/lolly_string_test.cpp
+++ b/tests/lolly/data/lolly_string_test.cpp
@@ -71,12 +71,25 @@ TEST_CASE ("test append") {
 }
 
 TEST_CASE ("test reserve along with append") {
-  auto str= string_u16 ();
-  str->reserve (6);
-  str << u'x';
-  CHECK_EQ (str == string_u16 (u"x"), true);
-  str << string_u16 (u"yz");
-  CHECK_EQ (str == string_u16 (u"xyz"), true);
-  str << string_u16 (u": larger than reserved space");
-  CHECK_EQ (str == string_u16 (u"xyz: larger than reserved space"), true);
+
+  SUBCASE ("reserved more space") {
+    auto str= string_u16 ();
+    str->reserve (6);
+    str << u'x';
+    CHECK_EQ (str == u"x", true);
+    str << string_u16 (u"yz");
+    CHECK_EQ (str == u"xyz", true);
+    str << string_u16 (u": larger than reserved space");
+    CHECK_EQ (str == u"xyz: larger than reserved space", true);
+  }
+  SUBCASE ("reserved the same space") {
+    auto str= string_u16 (u"abc");
+    str->reserve (3);
+    CHECK_EQ (str == u"abc", true);
+  }
+  SUBCASE ("reserved less space should take no effect") {
+    auto str= string_u16 (u"abc");
+    str->reserve (2);
+    CHECK_EQ (str == u"abc", true);
+  }
 }


### PR DESCRIPTION
## Works

* introduce `reserve` method;
    * works like [`std::basic_string::reserve`](https://zh.cppreference.com/w/cpp/string/basic_string/reserve)
* holds size of array in `a_N` field;
    * works like [`std::basic_string::capacity`](https://zh.cppreference.com/w/cpp/string/basic_string/capacity)
* introduce `expand_or_shrink_by` method to accelerate append of string.
    * `expand_or_shrink_by` avoid re-allocation whenever possible, so if a large string is shrink by `expand_or_shrink_by`, memory is not released.
    * `resize` works like [`std::basic_string::resize`](https://zh.cppreference.com/w/cpp/string/basic_string/resize), sometimes `resize` can be used as [`std::basic_string::shrink_to_fit`](https://zh.cppreference.com/w/cpp/string/basic_string/shrink_to_fit).
* add corresponding tests

## Example

use `reserve()` along with append operator:
```cpp
string r;
r.reserve(100);
for(int i=0; i<100; i++){
    r << (i%26) + 'a';
}
```

## Performance

### Before

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               79.08 |       12,645,769.22 |    0.8% |      0.95 | `construct string`
|               42.26 |       23,660,680.56 |    2.5% |      0.71 | `append string`

### After

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               75.58 |       13,231,790.34 |    0.9% |      0.90 | `construct string`
|               20.95 |       47,728,672.38 |    2.5% |      0.47 | `append string`