### PR TITLE
[12_30] url: disable the default url contructor

### DIFF
--- a/System/Classes/url.cpp
+++ b/System/Classes/url.cpp
@@ -57,7 +57,6 @@ is_tuple (url_tree t, const char* s, int n) {
   return (t->op == URL_TUPLE) && (N (t) == (n + 1)) && (t[0] == s);
 }
 
-url::url () : rep (tm_new<url_rep> (url_tuple ("none"))) {}
 url::url (const char* name) : rep (tm_new<url_rep> (url_system (name)->t)) {}
 url::url (string name) : rep (tm_new<url_rep> (url_system (name)->t)) {}
 url::url (string path_name, string name)

--- a/System/Classes/url.hpp
+++ b/System/Classes/url.hpp
@@ -41,7 +41,7 @@ private:
   url (url_tree t) : rep (tm_new<url_rep> (t)) {}
 
 public:
-  url ();
+  url ()= delete;
   url (const char* name);
   url (string name);
   url (string dir, string name);

--- a/System/Files/file.cpp
+++ b/System/Files/file.cpp
@@ -298,8 +298,8 @@ url_temp_dir_sub () {
 
 url
 url_temp_dir () {
-  static url u;
-  if (u == url_none ()) {
+  static url u= url_none ();
+  if (is_none (u)) {
     u= url_temp_dir_sub ();
     make_dir (u);
   }

--- a/tests/System/Classes/url_test.cpp
+++ b/tests/System/Classes/url_test.cpp
@@ -101,10 +101,8 @@ TEST_CASE ("is_none") {
   CHECK (!is_none (file_root));
   CHECK (is_none (none_url));
 
-  CHECK (is_none (url ()));
-  url_eq (url (), url_none ());
   CHECK (!is_none (url ("")));
-  url_neq (url (), url (""));
+  CHECK (!is_none (url_none ()));
 }
 
 TEST_CASE ("is_root") {

--- a/tests/System/Classes/url_test.cpp
+++ b/tests/System/Classes/url_test.cpp
@@ -102,7 +102,7 @@ TEST_CASE ("is_none") {
   CHECK (is_none (none_url));
 
   CHECK (!is_none (url ("")));
-  CHECK (!is_none (url_none ()));
+  CHECK (is_none (url_none ()));
 }
 
 TEST_CASE ("is_root") {


### PR DESCRIPTION
## What
Disable `url ()`.

## Why
Unify the method to use `url_none ()`.