### PR TITLE
[8_10] list: perf tuning on list_contains slightly

### DIFF
--- a/Kernel/Containers/list.ipp
+++ b/Kernel/Containers/list.ipp
@@ -220,7 +220,10 @@ remove (list<T> l, T what) {
 template <class T>
 bool
 contains (list<T> l, T what) {
-  return (!is_nil (l) && (l->item == what || contains (l->next, what)));
+  if (is_nil (l)) return false;
+  if (l->item == what) return true;
+
+  return contains (l->next, what);
 }
 
 #endif // defined LIST_CC

--- a/bench/Kernel/Containers/list_bench.cpp
+++ b/bench/Kernel/Containers/list_bench.cpp
@@ -33,5 +33,10 @@ main () {
   bench.run ("N 32", [&] { N (l32); });
 
   bench.minEpochIterations (40000);
+
+  bench.run ("contains 1", [&] {contains (l32, 1L); });
+  bench.run ("contains 16", [&] {contains (l32, 16L); });
+  bench.run ("contains 32", [&] {contains (l32, 32L); });
+
   bench.run ("l1 == l2 32", [&] { l32 == l32_2; });
 }

--- a/bench/Kernel/Containers/list_bench.cpp
+++ b/bench/Kernel/Containers/list_bench.cpp
@@ -34,10 +34,10 @@ main () {
   bench.run ("N 32", [&] { N (l32); });
 
   bench.minEpochIterations (100000);
-  bench.run ("contains 1", [&] {contains (l32, 1L); });
-  bench.run ("contains 16", [&] {contains (l32, 16L); });
-  bench.run ("contains 32", [&] {contains (l32, 32L); });
-  bench.run ("contains 64", [&] {contains (l32, 64L); });
+  bench.run ("contains 1", [&] { contains (l32, 1L); });
+  bench.run ("contains 16", [&] { contains (l32, 16L); });
+  bench.run ("contains 32", [&] { contains (l32, 32L); });
+  bench.run ("contains 64", [&] { contains (l32, 64L); });
 
   bench.minEpochIterations (40000);
   bench.run ("l1 == l2 32", [&] { l32 == l32_2; });

--- a/bench/Kernel/Containers/list_bench.cpp
+++ b/bench/Kernel/Containers/list_bench.cpp
@@ -25,6 +25,7 @@ main () {
   list<long> l16  = gen (16);
   list<long> l32  = gen (32);
   list<long> l32_2= gen (32);
+  list<long> l64  = gen (64);
 
   bench.run ("last_item 1", [&] { last_item (l1); });
   bench.run ("last_item 4", [&] { last_item (l4); });
@@ -32,11 +33,12 @@ main () {
 
   bench.run ("N 32", [&] { N (l32); });
 
-  bench.minEpochIterations (40000);
-
+  bench.minEpochIterations (100000);
   bench.run ("contains 1", [&] {contains (l32, 1L); });
   bench.run ("contains 16", [&] {contains (l32, 16L); });
   bench.run ("contains 32", [&] {contains (l32, 32L); });
+  bench.run ("contains 64", [&] {contains (l32, 64L); });
 
+  bench.minEpochIterations (40000);
   bench.run ("l1 == l2 32", [&] { l32 == l32_2; });
 }


### PR DESCRIPTION
Before:

```
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.76 |    1,312,761,217.20 |    3.1% |      0.01 | `last_item 1`
|                3.07 |      325,298,326.95 |    4.5% |      0.01 | `last_item 4`
|               19.44 |       51,427,537.40 |    8.4% |      0.01 | :wavy_dash: `last_item 16` (Unstable with ~59,211.2 iters. Increase `minEpochIterations` to e.g. 592112)
|               57.67 |       17,340,734.42 |    0.7% |      0.01 | `N 32`
|                2.33 |      430,092,564.26 |    1.4% |      0.01 | `contains 1`
|               36.14 |       27,669,848.68 |    4.6% |      0.04 | `contains 16`
|               75.11 |       13,314,333.57 |    3.9% |      0.09 | `contains 32`
|               80.67 |       12,396,511.82 |    3.6% |      0.09 | `contains 64`
```

After:
```
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.77 |    1,297,115,011.55 |   11.7% |      0.01 | :wavy_dash: `last_item 1` (Unstable with ~1,590,753.5 iters. Increase `minEpochIterations` to e.g. 15907535)
|                3.07 |      325,784,359.09 |    2.1% |      0.01 | `last_item 4`
|               18.64 |       53,659,753.89 |    2.0% |      0.01 | `last_item 16`
|               51.32 |       19,487,411.88 |    3.0% |      0.01 | `N 32`
|                2.24 |      446,784,980.38 |    3.8% |      0.01 | `contains 1`
|               33.65 |       29,715,032.84 |    2.6% |      0.04 | `contains 16`
|               69.80 |       14,326,172.14 |    2.9% |      0.08 | `contains 32`
|               70.98 |       14,088,835.88 |    4.3% |      0.08 | `contains 64`
```