### PR TITLE
[8_10] list: perf tuning on list append

### DIFF
--- a/bench/Kernel/Containers/list_bench.cpp
+++ b/bench/Kernel/Containers/list_bench.cpp
@@ -39,6 +39,12 @@ main () {
   bench.run ("contains 32", [&] { contains (l32, 32L); });
   bench.run ("contains 64", [&] { contains (l32, 64L); });
 
+  bench.run ("append item 1", [&] { l1 * 2L; });
+  bench.run ("append item 4", [&] { l4 * 2L; });
+  bench.run ("append item 16", [&] { l16 * 2L; });
+  bench.run ("append item 32", [&] { l32 * 2L; });
+  bench.run ("append item 64", [&] { l64 * 2L; });
+
   bench.minEpochIterations (40000);
   bench.run ("l1 == l2 32", [&] { l32 == l32_2; });
 }


### PR DESCRIPTION
Before
```
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                0.66 |    1,512,533,333.33 |    1.2% |      0.01 | `last_item 1`
|                3.67 |      272,494,287.54 |    5.2% |      0.01 | :wavy_dash: `last_item 4` (Unstable with ~299,725.8 iters. Increase `minEpochIterations` to e.g. 2997258)
|               22.32 |       44,803,317.94 |    2.0% |      0.01 | `last_item 16`
|               65.48 |       15,270,758.12 |    2.5% |      0.01 | `N 32`
|                2.36 |      424,382,599.76 |    0.2% |      0.01 | `contains 1`
|               36.88 |       27,114,049.81 |    8.4% |      0.04 | :wavy_dash: `contains 16` (Unstable with ~108,543.5 iters. Increase `minEpochIterations` to e.g. 1085435)
|               68.50 |       14,598,676.07 |    5.1% |      0.08 | :wavy_dash: `contains 32` (Unstable with ~108,543.5 iters. Increase `minEpochIterations` to e.g. 1085435)
|               68.80 |       14,535,306.26 |    7.3% |      0.09 | :wavy_dash: `contains 64` (Unstable with ~108,543.5 iters. Increase `minEpochIterations` to e.g. 1085435)
|               16.99 |       58,869,736.52 |    8.0% |      0.02 | :wavy_dash: `append item 1` (Unstable with ~108,543.5 iters. Increase `minEpochIterations` to e.g. 1085435)
|               49.99 |       20,002,097.06 |    7.6% |      0.06 | :wavy_dash: `append item 4` (Unstable with ~108,543.5 iters. Increase `minEpochIterations` to e.g. 1085435)
|              171.87 |        5,818,489.18 |    5.8% |      0.20 | :wavy_dash: `append item 16` (Unstable with ~108,543.5 iters. Increase `minEpochIterations` to e.g. 1085435)
|              337.60 |        2,962,085.92 |    5.3% |      0.41 | :wavy_dash: `append item 32` (Unstable with ~108,543.5 iters. Increase `minEpochIterations` to e.g. 1085435)
|              656.60 |        1,523,004.74 |    2.2% |      0.80 | `append item 64`
|              176.06 |        5,679,839.41 |    3.7% |      0.08 | `l1 == l2 32`
```