### PR TITLE
[21_6] string_u8 as an alias of string

### DIFF
--- a/Kernel/Types/string.hpp
+++ b/Kernel/Types/string.hpp
@@ -121,4 +121,6 @@ public:
 };
 CONCRETE_CODE (c_string);
 
+typedef string string_u8;
+
 #endif // defined STRING_H


### PR DESCRIPTION
## Why
Use string_u8 to show that the string is encoded in UTF-8. It is identical to string in implementation.