### PR TITLE
[8_12] improve strategy of expanding string for performance 

### DIFF
--- a/Kernel/Types/string.hpp
+++ b/Kernel/Types/string.hpp
@@ -23,15 +23,37 @@ using lolly::data::string_view;
 class string;
 class string_rep : concrete_struct {
   int   n;
+  int   a_N;
   char* a;
 
 public:
-  inline string_rep () : n (0), a (NULL) {}
+  inline string_rep () : n (0), a_N (0), a (NULL) {}
   string_rep (int n);
   inline ~string_rep () {
     if (n != 0) tm_delete_array (a);
   }
+  /**
+   * @brief expand (or shrink) string by delta, but do not release memory when
+   * string is shrinked.
+   *
+   * @return string length before expansion
+   */
+  int expand_or_shrink_by (int delta);
+
+  /**
+   * @brief expand (or shrink) string to given length n, and try to release
+   * memory when string is shrinked.
+   *
+   * @note expand_or_shrink_by may be faster if memory space is reserved
+   */
   void resize (int n);
+
+  /**
+   * @brief reserve memory space to contain at least n word in the whole string.
+   * Do not affect length of string, and do not release memory when n is smaller
+   * than current space.
+   */
+  void reserve (int n);
 
   friend class string;
   friend inline int N (string a);

--- a/bench/Kernel/Types/string_bench.cpp
+++ b/bench/Kernel/Types/string_bench.cpp
@@ -14,6 +14,7 @@ static ankerl::nanobench::Bench bench;
 int
 main () {
   lolly::init_tbox ();
+  bench.minEpochTime (std::chrono::milliseconds (20));
   bench.run ("construct string", [&] {
     string ("abc");
     string ();
@@ -43,7 +44,6 @@ main () {
     static string a ("abcdefgh");
     a (1, 6);
   });
-  bench.minEpochIterations (40000);
   bench.run ("concat string", [&] {
     static string a ("abc"), b ("de");
     a*            b;

--- a/tests/Kernel/Types/string_test.cpp
+++ b/tests/Kernel/Types/string_test.cpp
@@ -64,6 +64,81 @@ TEST_CASE ("test append") {
   CHECK_EQ (str == string ("xyz"), true);
 }
 
+TEST_CASE ("test append") {
+  auto str= string ();
+  str << 'x';
+  CHECK (str == "x");
+  str << string ("yz");
+  CHECK (str == "xyz");
+}
+
+TEST_CASE ("test reserve along with append") {
+
+  SUBCASE ("reserved more space") {
+    auto str= string ();
+    str->reserve (6);
+    str << 'x';
+    CHECK_EQ (str == "x", true);
+    str << string ("yz");
+    CHECK_EQ (str == "xyz", true);
+    str << string (": larger than reserved space");
+    CHECK_EQ (str == "xyz: larger than reserved space", true);
+  }
+  SUBCASE ("reserved the same space") {
+    auto str= string ("abc");
+    str->reserve (3);
+    CHECK_EQ (str == "abc", true);
+  }
+  SUBCASE ("reserved less space should take no effect") {
+    auto str= string ("abc");
+    str->reserve (2);
+    CHECK_EQ (str == "abc", true);
+  }
+}
+
+TEST_CASE ("test expand_or_shrink_by along with sub index") {
+
+  SUBCASE ("expand") {
+    auto str       = string ("abc");
+    int  previous_n= str->expand_or_shrink_by (1);
+    CHECK_EQ (previous_n, 3);
+    str[3]= 'd';
+    CHECK_EQ (str == "abcd", true);
+  }
+  SUBCASE ("shrink") {
+    auto str       = string ("abc");
+    int  previous_n= str->expand_or_shrink_by (-1);
+    CHECK_EQ (previous_n, 3);
+    CHECK_EQ (str == "ab", true);
+  }
+  SUBCASE ("delta 0 takes no effect") {
+    auto str       = string ("abc");
+    int  previous_n= str->expand_or_shrink_by (0);
+    CHECK_EQ (previous_n, 3);
+    CHECK_EQ (str == "abc", true);
+  }
+}
+
+TEST_CASE ("test resize") {
+
+  SUBCASE ("expand") {
+    auto str= string ("abc");
+    str->resize (4);
+    str[3]= 'd';
+    CHECK_EQ (str == "abcd", true);
+  }
+  SUBCASE ("shrink") {
+    auto str= string ("abc");
+    str->resize (2);
+    CHECK_EQ (str == "ab", true);
+  }
+  SUBCASE ("delta 0 takes no effect") {
+    auto str= string ("abc");
+    str->resize (3);
+    CHECK_EQ (str == "abc", true);
+  }
+}
+
 /******************************************************************************
  * Conversions
  ******************************************************************************/


### PR DESCRIPTION
see also #305 

## Performance

`operator<<` faster 2-3x than before

### Before

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               35.13 |       28,463,649.27 |    3.9% |      0.22 | `construct string`
|                2.66 |      376,488,992.00 |    1.7% |      0.24 | `equality of string`
|               17.68 |       56,561,986.49 |    1.0% |      0.23 | `equality of larger string`
|                4.14 |      241,610,858.14 |    0.9% |      0.24 | `compare string`
|                8.09 |      123,542,843.98 |    2.1% |      0.24 | `compare larger string`
|               18.23 |       54,847,647.47 |    0.6% |      0.24 | `slice string`
|               24.93 |       40,119,524.68 |    2.0% |      0.24 | `slice string with larger range`
|               31.80 |       31,447,902.44 |    0.9% |      0.24 | `concat string`
|               16.71 |       59,850,717.22 |    2.5% |      0.24 | `append string`
|                3.17 |      315,195,579.00 |    0.5% |      0.24 | `is quoted`

### After

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               33.35 |       29,984,690.73 |    2.4% |      0.23 | `construct string`
|                2.64 |      378,639,521.02 |    2.0% |      0.24 | `equality of string`
|               15.69 |       63,733,330.98 |    3.0% |      0.23 | `equality of larger string`
|                4.22 |      236,987,827.04 |    3.2% |      0.25 | `compare string`
|                8.50 |      117,694,065.06 |    3.1% |      0.24 | `compare larger string`
|               22.21 |       45,014,771.61 |    3.7% |      0.23 | `slice string`
|               25.88 |       38,644,124.66 |    0.3% |      0.24 | `slice string with larger range`
|               30.28 |       33,028,549.24 |    0.9% |      0.24 | `concat string`
|                6.81 |      146,814,049.22 |    3.7% |      0.23 | `append string`
|                3.20 |      312,586,648.76 |    0.7% |      0.23 | `is quoted`