### PR TITLE
[8_13] improve performance when calculating hash of string

### DIFF
--- a/Kernel/Types/string.cpp
+++ b/Kernel/Types/string.cpp
@@ -221,10 +221,10 @@ operator<= (string s1, string s2) {
 
 int
 hash (string s) {
-  int i, h= 0, n= N (s);
-  for (i= 0; i < n; i++) {
+  int h= 0;
+  for (char ch : s) {
     h= (h << 9) + (h >> 23);
-    h= h + ((int) s[i]);
+    h= h + ((int) ch);
   }
   return h;
 }

--- a/bench/Kernel/Types/string_bench.cpp
+++ b/bench/Kernel/Types/string_bench.cpp
@@ -54,11 +54,11 @@ main () {
   });
   bench.run ("hash of string", [&] {
     static string a ("accde");
-    hash(a);
+    hash (a);
   });
   bench.run ("hash of larger string", [&] {
     static string a ("compare larger string ,compute hash of LARGER string");
-    hash(a);
+    hash (a);
   });
   bench.run ("is quoted", [&] {
     static string a ("H\"ello TeXmacs\"");

--- a/bench/Kernel/Types/string_bench.cpp
+++ b/bench/Kernel/Types/string_bench.cpp
@@ -52,6 +52,14 @@ main () {
     static string a ("abc"), b ("de");
     a << b;
   });
+  bench.run ("hash of string", [&] {
+    static string a ("accde");
+    hash(a);
+  });
+  bench.run ("hash of larger string", [&] {
+    static string a ("compare larger string ,compute hash of LARGER string");
+    hash(a);
+  });
   bench.run ("is quoted", [&] {
     static string a ("H\"ello TeXmacs\"");
     is_quoted (a);


### PR DESCRIPTION

## Performance

`hash(string)` is 110%-120% faster than before.

### Before

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                6.86 |      145,850,216.76 |    0.7% |      0.24 | `hash of string`
|               59.22 |       16,887,153.73 |    1.1% |      0.24 | `hash of larger string`

### After

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                6.22 |      160,754,437.19 |    0.3% |      0.24 | `hash of string`
|               50.64 |       19,747,047.60 |    0.2% |      0.24 | `hash of larger string`
