### PR TITLE
[8_11] optimize performance of as_hexadecimal

### DIFF
--- a/bench/lolly/data/numeral_bench.cpp
+++ b/bench/lolly/data/numeral_bench.cpp
@@ -31,7 +31,7 @@ main () {
     bench.complexityN (d);
     bench.run ("convert hexadecimal string to int",
                [&] { from_hex (hex_string); });
-    int hex_number= (0x1 << (d + 1)) - 1;
+    int hex_number= (0x1 << ((d + 1) * 4)) - 1;
     bench.run ("convert signed int to hexadecimal string",
                [&] { to_Hex (hex_number); });
     bench.run ("convert unsigned int to hexadecimal string",

--- a/lolly/data/numeral.cpp
+++ b/lolly/data/numeral.cpp
@@ -233,12 +233,12 @@ from_hex (string s) {
  * to the tail.
  * @tparam T unsigned integral type is expected.
  */
-template <typename T>
+template <unsigned int cur, typename T>
 std::enable_if_t<std::conjunction_v<std::is_integral<T>, std::is_unsigned<T>>,
                  void>
-as_hexadecimal_sub (T i, unsigned int cur, string& s) {
-  if (cur > 0) {
-    as_hexadecimal_sub (i >> 4, cur - 1, s);
+as_hexadecimal_sub (T i, string& s) {
+  if constexpr (cur > 0) {
+    as_hexadecimal_sub<cur - 1> (i >> 4, s);
   }
   s[cur]= hex_string[i & 15];
 }
@@ -246,7 +246,59 @@ as_hexadecimal_sub (T i, unsigned int cur, string& s) {
 string
 as_hexadecimal (int i, int len) {
   string result (len);
-  as_hexadecimal_sub ((unsigned) i, len - 1, result);
+  switch (len) {
+  case 1:
+    as_hexadecimal_sub<0> ((unsigned int) i, result);
+    break;
+  case 2:
+    as_hexadecimal_sub<1> ((unsigned int) i, result);
+    break;
+  case 3:
+    as_hexadecimal_sub<2> ((unsigned int) i, result);
+    break;
+  case 4:
+    as_hexadecimal_sub<3> ((unsigned int) i, result);
+    break;
+  case 5:
+    as_hexadecimal_sub<4> ((unsigned int) i, result);
+    break;
+  case 6:
+    as_hexadecimal_sub<5> ((unsigned int) i, result);
+    break;
+  case 7:
+    as_hexadecimal_sub<6> ((unsigned int) i, result);
+    break;
+  case 8:
+    as_hexadecimal_sub<7> ((unsigned int) i, result);
+    break;
+  case 9:
+    as_hexadecimal_sub<8> ((unsigned int) i, result);
+    break;
+  case 10:
+    as_hexadecimal_sub<9> ((unsigned int) i, result);
+    break;
+  case 11:
+    as_hexadecimal_sub<10> ((unsigned int) i, result);
+    break;
+  case 12:
+    as_hexadecimal_sub<11> ((unsigned int) i, result);
+    break;
+  case 13:
+    as_hexadecimal_sub<12> ((unsigned int) i, result);
+    break;
+  case 14:
+    as_hexadecimal_sub<13> ((unsigned int) i, result);
+    break;
+  case 15:
+    as_hexadecimal_sub<14> ((unsigned int) i, result);
+    break;
+  case 16:
+    as_hexadecimal_sub<15> ((unsigned int) i, result);
+    break;
+  default:
+    TM_FAILED ("len is too large");
+    break;
+  }
   return result;
 }
 


### PR DESCRIPTION
## Performance

### Before


| complexityN |               ns/op |                op/s |    err% |     total | benchmark
|------------:|--------------------:|--------------------:|--------:|----------:|:----------
|           1 |               16.13 |       61,983,083.42 |    1.1% |      0.08 | `convert unsigned int to hexadecimal string`
|           2 |               17.66 |       56,613,212.10 |    1.6% |      0.09 | `convert unsigned int to hexadecimal string`
|           3 |               18.61 |       53,742,458.03 |    0.4% |      0.09 | `convert unsigned int to hexadecimal string`
|           4 |               20.91 |       47,819,863.10 |    0.6% |      0.10 | `convert unsigned int to hexadecimal string`
|           5 |               24.17 |       41,368,070.45 |    0.4% |      0.12 | `convert unsigned int to hexadecimal string`

### After

| complexityN |               ns/op |                op/s |    err% |     total | benchmark
|------------:|--------------------:|--------------------:|--------:|----------:|:----------
|           1 |               15.82 |       63,221,389.11 |    0.4% |      0.08 | `convert unsigned int to hexadecimal string`
|           2 |               15.76 |       63,449,120.53 |    1.6% |      0.08 | `convert unsigned int to hexadecimal string`
|           3 |               17.98 |       55,615,898.20 |    1.0% |      0.09 | `convert unsigned int to hexadecimal string`
|           4 |               17.53 |       57,043,784.30 |    2.8% |      0.08 | `convert unsigned int to hexadecimal string`
|           5 |               16.19 |       61,784,470.21 |    0.4% |      0.08 | `convert unsigned int to hexadecimal string`
