### PR TITLE
[8_11] add binary_to_hexadecimal interface

### DIFF
--- a/bench/lolly/data/numeral_bench.cpp
+++ b/bench/lolly/data/numeral_bench.cpp
@@ -5,12 +5,11 @@
  *  \date   2024
  */
 
+#include "file.hpp"
 #include "lolly/data/numeral.hpp"
 #include <nanobench.h>
 
 using namespace lolly::data;
-
-static ankerl::nanobench::Bench bench;
 
 namespace lolly {
 extern void init_tbox ();
@@ -19,6 +18,7 @@ extern void init_tbox ();
 int
 main () {
   lolly::init_tbox ();
+  ankerl::nanobench::Bench bench;
 #ifdef OS_WASM
   bench.minEpochIterations (2000);
 #else
@@ -37,4 +37,17 @@ main () {
     bench.run ("convert unsigned int to hexadecimal string",
                [&] { as_hexadecimal (hex_number, d); });
   }
+  string                   content= string_load (url_pwd () * "LICENSE");
+  ankerl::nanobench::Bench bench2;
+  bench2.relative (true)
+      .minEpochTime (std::chrono::milliseconds (10))
+      .run ("convert document to hexadecimal string, legacy",
+            [&] {
+              string result;
+              for (int i= 0; i < N (content); i++)
+                result << as_hexadecimal ((unsigned char) content[i], 2);
+            })
+      .run (
+          "convert document to hexadecimal string, using binary_to_hexadecimal",
+          [&] { string result= binary_to_hexadecimal (content); });
 }

--- a/lolly/data/numeral.cpp
+++ b/lolly/data/numeral.cpp
@@ -312,11 +312,11 @@ as_hexadecimal (uint32_t i) {
 string
 binary_to_hexadecimal (string bin) {
   string res ((int) (N (bin) * 2));
-  int cur=0;
+  int    cur= 0;
   for (unsigned char ch : bin) {
-    res[cur] = hex_string[ch >> 4];
-    res[cur+1] = hex_string[ch & 0x0f];
-    cur += 2;
+    res[cur]    = hex_string[ch >> 4];
+    res[cur + 1]= hex_string[ch & 0x0f];
+    cur+= 2;
   }
   return res;
 }

--- a/lolly/data/numeral.cpp
+++ b/lolly/data/numeral.cpp
@@ -309,5 +309,17 @@ as_hexadecimal (uint32_t i) {
   return result;
 }
 
+string
+binary_to_hexadecimal (string bin) {
+  string res ((int) (N (bin) * 2));
+  int cur=0;
+  for (unsigned char ch : bin) {
+    res[cur] = hex_string[ch >> 4];
+    res[cur+1] = hex_string[ch & 0x0f];
+    cur += 2;
+  }
+  return res;
+}
+
 } // namespace data
 } // namespace lolly

--- a/lolly/data/numeral.hpp
+++ b/lolly/data/numeral.hpp
@@ -100,5 +100,13 @@ string as_hexadecimal (int i, int length);
  */
 string as_hexadecimal (uint32_t i);
 
+/**
+ * @brief Converts a binary stream to its hexadecimal represention.
+ *
+ * @param bin The binary data to be converted to a hexadecimal string.
+ * @return The hexadecimal string representation of the input binary.
+ */
+string binary_to_hexadecimal (string bin);
+
 } // namespace data
 } // namespace lolly

--- a/tests/lolly/data/numeral_test.cpp
+++ b/tests/lolly/data/numeral_test.cpp
@@ -198,3 +198,11 @@ TEST_CASE ("as_hexadecimal") {
   }
   SUBCASE ("max") { string_eq (as_hexadecimal (UINT32_MAX), "FFFFFFFF"); }
 }
+
+TEST_CASE ("binary to hexadecimal") {
+  string header_of_png;
+  header_of_png << "\xff\xd8\xff\xe0";
+  header_of_png << '\x00';
+  header_of_png << "\x10\x4A\x46\x49\x46";
+  string_eq (binary_to_hexadecimal (header_of_png), "FFD8FFE000104A464946");
+}


### PR DESCRIPTION
## Performance

9x faster than legacy algorithm

| relative |               ns/op |                op/s |    err% |     total | benchmark
|---------:|--------------------:|--------------------:|--------:|----------:|:----------
|   100.0% |          741,626.67 |            1,348.39 |    0.6% |      0.11 | `convert document to hexadecimal string, legacy`
| 1,107.8% |           66,947.70 |           14,937.03 |    1.0% |      0.11 | `convert document to hexadecimal string, using binary_to_hexadecimal`