### PR TITLE
[8_12] improve strategy of expanding string for performance

### DIFF
--- a/Kernel/Types/string.cpp
+++ b/Kernel/Types/string.cpp
@@ -31,9 +31,11 @@ round_length (int n) {
   return i;
 }
 
-string_rep::string_rep (int n2)
-    : n (n2), a_N (round_length (n)),
-      a ((n == 0) ? ((char*) NULL) : tm_new_array<char> (round_length (n))) {}
+string_rep::string_rep (int n2) : n (n2), a_N (round_length (n2)), a (nullptr) {
+  if (a_N != 0) {
+    a= tm_new_array<char> (a_N);
+  }
+}
 
 void
 string_rep::resize (int m) {

--- a/Kernel/Types/string.hpp
+++ b/Kernel/Types/string.hpp
@@ -23,8 +23,8 @@ using lolly::data::string_view;
 class string;
 class string_rep : concrete_struct {
   int   n;
-  int   a_N;
   char* a;
+  int   a_N;
 
 public:
   inline string_rep () : n (0), a_N (0), a (NULL) {}

--- a/Kernel/Types/string.hpp
+++ b/Kernel/Types/string.hpp
@@ -30,7 +30,7 @@ public:
   inline string_rep () : n (0), a_N (0), a (NULL) {}
   string_rep (int n);
   inline ~string_rep () {
-    if (n != 0) tm_delete_array (a);
+    if (a_N != 0) tm_delete_array (a);
   }
   /**
    * @brief expand (or shrink) string by delta, but do not release memory when

--- a/Kernel/Types/string.hpp
+++ b/Kernel/Types/string.hpp
@@ -23,15 +23,37 @@ using lolly::data::string_view;
 class string;
 class string_rep : concrete_struct {
   int   n;
+  int   a_N;
   char* a;
 
 public:
-  inline string_rep () : n (0), a (NULL) {}
+  inline string_rep () : n (0), a_N (0), a (NULL) {}
   string_rep (int n);
   inline ~string_rep () {
     if (n != 0) tm_delete_array (a);
   }
+  /**
+   * @brief expand (or shrink) string by delta, but do not release memory when
+   * string is shrinked.
+   *
+   * @return string length before expansion
+   */
+  int expand_or_shrink_by (int delta);
+
+  /**
+   * @brief expand (or shrink) string to given length n, and try to release
+   * memory when string is shrinked.
+   *
+   * @note expand_or_shrink_by may be faster if memory space is reserved
+   */
   void resize (int n);
+
+  /**
+   * @brief reserve memory space to contain at least n word in the whole string.
+   * Do not affect length of string, and do not release memory when n is smaller
+   * than current space.
+   */
+  void reserve (int n);
 
   friend class string;
   friend inline int N (string a);

--- a/bench/Kernel/Types/string_bench.cpp
+++ b/bench/Kernel/Types/string_bench.cpp
@@ -14,6 +14,7 @@ static ankerl::nanobench::Bench bench;
 int
 main () {
   lolly::init_tbox ();
+  bench.minEpochTime (std::chrono::milliseconds (20));
   bench.run ("construct string", [&] {
     string ("abc");
     string ();
@@ -43,7 +44,6 @@ main () {
     static string a ("abcdefgh");
     a (1, 6);
   });
-  bench.minEpochIterations (40000);
   bench.run ("concat string", [&] {
     static string a ("abc"), b ("de");
     a*            b;

--- a/tests/Kernel/Types/string_test.cpp
+++ b/tests/Kernel/Types/string_test.cpp
@@ -64,6 +64,81 @@ TEST_CASE ("test append") {
   CHECK_EQ (str == string ("xyz"), true);
 }
 
+TEST_CASE ("test append") {
+  auto str= string ();
+  str << 'x';
+  CHECK (str == "x");
+  str << string ("yz");
+  CHECK (str == "xyz");
+}
+
+TEST_CASE ("test reserve along with append") {
+
+  SUBCASE ("reserved more space") {
+    auto str= string ();
+    str->reserve (6);
+    str << 'x';
+    CHECK_EQ (str == "x", true);
+    str << string ("yz");
+    CHECK_EQ (str == "xyz", true);
+    str << string (": larger than reserved space");
+    CHECK_EQ (str == "xyz: larger than reserved space", true);
+  }
+  SUBCASE ("reserved the same space") {
+    auto str= string ("abc");
+    str->reserve (3);
+    CHECK_EQ (str == "abc", true);
+  }
+  SUBCASE ("reserved less space should take no effect") {
+    auto str= string ("abc");
+    str->reserve (2);
+    CHECK_EQ (str == "abc", true);
+  }
+}
+
+TEST_CASE ("test expand_or_shrink_by along with sub index") {
+
+  SUBCASE ("expand") {
+    auto str       = string ("abc");
+    int  previous_n= str->expand_or_shrink_by (1);
+    CHECK_EQ (previous_n, 3);
+    str[3]= 'd';
+    CHECK_EQ (str == "abcd", true);
+  }
+  SUBCASE ("shrink") {
+    auto str       = string ("abc");
+    int  previous_n= str->expand_or_shrink_by (-1);
+    CHECK_EQ (previous_n, 3);
+    CHECK_EQ (str == "ab", true);
+  }
+  SUBCASE ("delta 0 takes no effect") {
+    auto str       = string ("abc");
+    int  previous_n= str->expand_or_shrink_by (0);
+    CHECK_EQ (previous_n, 3);
+    CHECK_EQ (str == "abc", true);
+  }
+}
+
+TEST_CASE ("test resize") {
+
+  SUBCASE ("expand") {
+    auto str= string ("abc");
+    str->resize (4);
+    str[3]= 'd';
+    CHECK_EQ (str == "abcd", true);
+  }
+  SUBCASE ("shrink") {
+    auto str= string ("abc");
+    str->resize (2);
+    CHECK_EQ (str == "ab", true);
+  }
+  SUBCASE ("delta 0 takes no effect") {
+    auto str= string ("abc");
+    str->resize (3);
+    CHECK_EQ (str == "abc", true);
+  }
+}
+
 /******************************************************************************
  * Conversions
  ******************************************************************************/


### PR DESCRIPTION
This pr ensure the layout consistency between array and string, by make member pointer appears at the same position of class, so that union inside tree will not be broken.

#331 
```cpp
class string{
int n;
int a_N;
char* a;
//...
}

template<class T>
class array<T>{
int n;
T* a;
//...
}
```

this pr
```cpp
class string{
int n;
char* a;
int a_N;
//...
}

template<class T>
class array<T>{
int n;
T* a;
//...
}
```

## Performance

### Before
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               28.76 |       34,766,499.89 |    1.9% |      0.23 | `construct string`
|                2.15 |      465,519,808.15 |    1.1% |      0.24 | `equality of string`
|               12.29 |       81,372,418.85 |    3.4% |      0.24 | `equality of larger string`
|                3.67 |      272,834,596.28 |    1.0% |      0.24 | `compare string`
|                6.77 |      147,721,592.92 |    1.4% |      0.24 | `compare larger string`
|               15.25 |       65,576,665.94 |    0.2% |      0.24 | `slice string`
|               25.84 |       38,706,819.98 |    0.6% |      0.24 | `slice string with larger range`
|               26.77 |       37,362,109.49 |    1.9% |      0.24 | `concat string`
|               14.44 |       69,248,803.63 |    2.7% |      0.23 | `append string`
|                3.95 |      253,250,191.20 |    0.7% |      0.24 | `hash of string`
|               31.15 |       32,099,101.32 |    0.5% |      0.24 | `hash of larger string`
|                2.45 |      408,268,298.94 |    1.1% |      0.24 | `is quoted`

### After
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               33.28 |       30,048,811.93 |    0.5% |      0.24 | `construct string`
|                2.10 |      476,358,528.82 |    1.9% |      0.24 | `equality of string`
|               12.61 |       79,290,902.83 |    3.3% |      0.24 | `equality of larger string`
|                3.69 |      271,309,979.88 |    1.5% |      0.24 | `compare string`
|                6.98 |      143,291,461.49 |    1.6% |      0.24 | `compare larger string`
|               15.86 |       63,070,424.48 |    1.1% |      0.23 | `slice string`
|               22.09 |       45,270,914.17 |    0.3% |      0.24 | `slice string with larger range`
|               25.83 |       38,707,374.61 |    2.1% |      0.24 | `concat string`
|                5.74 |      174,232,028.58 |    2.3% |      0.22 | `append string`
|                3.42 |      292,593,737.92 |    0.6% |      0.24 | `hash of string`
|               33.60 |       29,760,571.57 |    1.2% |      0.24 | `hash of larger string`
|                2.35 |      424,756,682.83 |    0.8% |      0.24 | `is quoted`