### PR TITLE
before

### DIFF
--- a/bench/Kernel/Containers/list_bench.cpp
+++ b/bench/Kernel/Containers/list_bench.cpp
@@ -41,4 +41,7 @@ main () {
 
   bench.minEpochIterations (40000);
   bench.run ("l1 == l2 32", [&] { l32 == l32_2; });
+
+  bench.run ("remove 31 of 64", [&] { remove (l64, 31L); });
+  bench.run ("remove 63 of 64", [&] { remove (l64, 63L); });
 }


### PR DESCRIPTION
Before
```
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                1.77 |      565,092,376.55 |    9.9% |      0.01 | :wavy_dash: `last_item 1` (Unstable with ~678,695.5 iters. Increase `minEpochIterations` to e.g. 6786955)
|                5.92 |      168,871,728.07 |    2.1% |      0.01 | `last_item 4`
|               36.84 |       27,146,163.80 |   12.1% |      0.01 | :wavy_dash: `last_item 16` (Unstable with ~29,840.3 iters. Increase `minEpochIterations` to e.g. 298403)
|               49.80 |       20,082,190.76 |    0.3% |      0.01 | `N 32`
|                2.01 |      496,974,861.38 |    0.3% |      0.01 | `contains 1`
|               30.28 |       33,023,476.01 |    2.0% |      0.04 | `contains 16`
|               55.49 |       18,020,389.30 |    1.0% |      0.07 | `contains 32`
|               55.78 |       17,927,752.30 |    0.4% |      0.07 | `contains 64`
|              208.82 |        4,788,766.70 |    1.6% |      0.10 | `l1 == l2 32`
|            1,059.71 |          943,651.60 |    0.6% |      0.51 | `remove 31 of 64`
|            1,018.77 |          981,579.94 |    0.2% |      0.49 | `remove 63 of 64`
```
