### PR TITLE
support ./bin/list_tests and fix the docs

### DIFF
--- a/bin/list_tests.sh
+++ b/bin/list_tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+find tests -type f -name '*_test.cpp' \
+  | sed -E 's!.*/([^/]+)\.cpp$!\1!' \
+  | sort \
+  | column

--- a/docs/guide/Test.md
+++ b/docs/guide/Test.md
@@ -1,19 +1,23 @@
 # How to Perform Testing
 For developers, there are two testing methods available: unit testing and integration testing.
 
+## Configuration
+
+```
+xmake config --enable_tests=true
+xmake build
+```
+
 ## Listing all Targets
 The following command line can list all targets. Targets ending with `_test` are C++ unit tests.
 ``` shell
-$ xmake show -l targets
-path_test            ntuple_test          fast_search_test
-base64_test          blackbox_test        hashset_test
-tm_timer_test        string_test          fast_alloc_test
-promise_test         liblolly             array_test
-url_test             sys_utils_test       hashmap_test
-curl_test            iterator_test        hashfunc_test
-hashtree_test        tm_ostream_test      list_test
-modification_test    parse_string_test    generic_tree_test
-analyze_test         rel_hashmap_test     tree_test
+chmod +x ./bin/list_tests.sh
+./bin/list_test.sh
+analyze_test            fast_search_test        hashset_test            md5_test                rel_hashmap_test        string_view_test        unicode_test
+array_test              file_test               hashtree_test           ntuple_test             shared_lib_test         subprocess_test         url_test
+base64_test             file_url_test           http_test               numeral_test            sha_test                sys_utils_test
+blackbox_test           hashfunc_test           iterator_test           parse_string_test       string_test             tm_ostream_test
+fast_alloc_test         hashmap_test            list_test               promise_test            string_u16_test         tm_timer_test
 ```
 
 ## Unit Tests
@@ -21,12 +25,10 @@ As shown above, unit tests are in the format of xxx_test. You can run the follow
 
 Run only one test:
 ```
-xmake run xxx_test
-bin\test_only.bat xxx_test # on Windows
-bin/test_only xxx_test     # on Linux/macOS
+xmake test tests/xxx_test
 ```
 
 Run all tests:
 ```
-xmake run --group=tests
+xmake test
 ```

--- a/docs/zh/guide/Test.md
+++ b/docs/zh/guide/Test.md
@@ -1,19 +1,23 @@
 # 如何测试
 对于开发者来说，一共有两种测试方式，其一为单元测试，其二为集成测试。
 
+## 配置
+
+```
+xmake config --enable_tests=true
+xmake build
+```
+
 ## 列出所有target
 下面的命令行可以列出所有target，其中以`_test`结尾的是C++的单元测试。
 ``` shell
-$ xmake show -l targets
-path_test            ntuple_test          fast_search_test
-base64_test          blackbox_test        hashset_test
-tm_timer_test        string_test          fast_alloc_test
-promise_test         liblolly             array_test
-url_test             sys_utils_test       hashmap_test
-curl_test            iterator_test        hashfunc_test
-hashtree_test        tm_ostream_test      list_test
-modification_test    parse_string_test    generic_tree_test
-analyze_test         rel_hashmap_test     tree_test
+chmod +x ./bin/list_tests.sh
+./bin/list_test.sh
+analyze_test            fast_search_test        hashset_test            md5_test                rel_hashmap_test        string_view_test        unicode_test
+array_test              file_test               hashtree_test           ntuple_test             shared_lib_test         subprocess_test         url_test
+base64_test             file_url_test           http_test               numeral_test            sha_test                sys_utils_test
+blackbox_test           hashfunc_test           iterator_test           parse_string_test       string_test             tm_ostream_test
+fast_alloc_test         hashmap_test            list_test               promise_test            string_u16_test         tm_timer_test
 ```
 
 ## 单元测试
@@ -21,13 +25,11 @@ analyze_test         rel_hashmap_test     tree_test
 
 运行单个单元测试：
 ```
-xmake run xxx_test
-bin\test_only.bat xxx_test # on Windows
-bin/test_only xxx_test     # on Linux/macOS
+xmake test tests/xxx_test
 ```
 
 运行所有单元测试：
 ```
-xmake run --group=tests
+xmake test
 ```
 


### PR DESCRIPTION
增加了列出test项目的脚本（因为原有的xmake show -l targets 不能正常工作， 以 _test 结尾的都是被默认隐藏（set_default(false)）的子 target）
并修正了文档运行测试的描述