### PR TITLE
[test] add file I/O and interoperability tests for tm_ostream

### DIFF
--- a/tests/System/IO/tm_ostream_test.cpp
+++ b/tests/System/IO/tm_ostream_test.cpp
@@ -188,7 +188,7 @@ TEST_CASE ("cout/cerr") {
   cerr << "棒棒糖" << LF;
 }
 
-TEST_MEMORY_LEAK_ALL
+TEST_MEMORY_LEAK_ALL 
 
 TEST_CASE ("tm_ostream opened on file") {
   url    file_path= url_temp ("lolly_test_output.txt");

--- a/tests/System/IO/tm_ostream_test.cpp
+++ b/tests/System/IO/tm_ostream_test.cpp
@@ -189,3 +189,55 @@ TEST_CASE ("cout/cerr") {
 }
 
 TEST_MEMORY_LEAK_ALL
+
+TEST_CASE ("tm_ostream opened on file") {
+  url    file_path= url_temp ("lolly_test_output.txt");
+  string content  = "Hello from tm_ostream file test!";
+
+  {
+    tm_ostream out (file_path);
+    CHECK (out->is_writable () == true);
+    out << content;
+  }
+
+  string loaded= "";
+  load_string (file_path, loaded, false);
+  CHECK (loaded == content);
+
+  remove (file_path);
+}
+
+TEST_CASE ("tm_ostream file with utf-8 filename") {
+  url    file_path= url_temp ("lolly_utf8_棒棒糖.txt");
+  string content  = "utf-8 content";
+
+  {
+    tm_ostream out (file_path);
+    CHECK (out->is_writable () == true);
+    out << content;
+  }
+
+  string loaded= "";
+  load_string (file_path, loaded, false);
+  CHECK (loaded == content);
+
+  remove (file_path);
+}
+
+TEST_CASE ("tm_ostream interoperability with load_string and save_string") {
+  url    file_path= url_temp ("lolly_interop_test.txt");
+  string content  = "interoperability test content";
+
+  save_string (file_path, content, false);
+
+  {
+    tm_ostream out (file_path);
+    CHECK (out->is_writable () == true);
+  }
+
+  string loaded= "";
+  load_string (file_path, loaded, false);
+  CHECK (loaded == content);
+
+  remove (file_path);
+}


### PR DESCRIPTION
Fixes #175

## Summary
Adds missing test coverage for `tm_ostream` opened on file,
as requested in Issue #175.

## New Test Cases Added
- `tm_ostream opened on file`: verifies tm_ostream can write
  to a real file and content is readable back via load_string()
- `tm_ostream file with utf-8 filename`: verifies tm_ostream
  works correctly with UTF-8 filenames (e.g. Chinese characters)
- `tm_ostream interoperability with load_string and save_string`:
  verifies round-trip between save_string(), tm_ostream, and
  load_string() produces consistent results

## Related Issue
Closes MoganLab/lolly#175